### PR TITLE
fixes issue: Connect panel is visually broken when Server is selected.

### DIFF
--- a/addon/globalPlugins/remoteClient/dialogs.py
+++ b/addon/globalPlugins/remoteClient/dialogs.py
@@ -56,6 +56,7 @@ class ServerPanel(wx.Panel):
 		self.generate_key = wx.Button(parent=self, label=_("&Generate Key"))
 		self.generate_key.Bind(wx.EVT_BUTTON, self.on_generate_key)
 		sizer.Add(self.generate_key)
+		self.SetSizerAndFit(sizer)
 
 	def on_generate_key(self, evt):
 		evt.Skip()


### PR DESCRIPTION
self.SetSizerAndFit(sizer) was missing at the end of `ServerPanel.__init__()`