### PR TITLE
Translator comments for add-on localization

### DIFF
--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -173,7 +173,10 @@ class GlobalPlugin(GlobalPlugin):
 	def on_slave_connection_failed(self):
 		if self.connector.successful_connects == 0:
 			self.disconnect_from_slave()
-			gui.messageBox(parent=gui.mainFrame, caption=_("Error Connecting"), message=_("Unable to connect to the remote computer"), style=wx.OK | wx.ICON_WARNING)
+			# Translators: Title of the connection error dialog.
+			gui.messageBox(parent=gui.mainFrame, caption=_("Error Connecting"),
+			# Translators: Message shown when cannot connect to the remote computer.
+			message=_("Unable to connect to the remote computer"), style=wx.OK | wx.ICON_WARNING)
 
 	def script_disconnect(self, gesture):
 		self.do_disconnect_from_slave()
@@ -184,6 +187,7 @@ class GlobalPlugin(GlobalPlugin):
 		last = ''
 		if last_cons:
 			last = last_cons[-1]
+		# Translators: Title of the connect dialog.
 		dlg = dialogs.DirectConnectDialog(parent=gui.mainFrame, id=wx.ID_ANY, title=_("Connect"))
 		dlg.panel.host.SetValue(last)
 		dlg.panel.host.SelectAll()
@@ -220,10 +224,12 @@ class GlobalPlugin(GlobalPlugin):
 		self.hook_thread = threading.Thread(target=self.hook)
 		self.hook_thread.daemon = True
 		self.hook_thread.start()
+		# Translators: Presented when connected to the remote computer.
 		ui.message(_("Connected!"))
 		beep_sequence.beep_sequence((440, 60), (660, 60))
 
 	def on_disconnected_from_slave(self):
+		# Translators: Presented when connection to a remote computer was interupted.
 		ui.message(_("Connection interrupted"))
 #		self.do_disconnect_from_slave(quiet=True)
 
@@ -256,6 +262,7 @@ class GlobalPlugin(GlobalPlugin):
 	def connected_to_relay(self):
 		log.info("Control connector connected")
 		beep_sequence.beep_sequence((720, 100), 50, (720, 100), 50, (720, 100))
+		# Transaltors: Presented in direct (client to server) remote connection when the controlled computer is ready.
 		speech.speakMessage(_("Connected to control server"))
 		self.push_clipboard_item.Enable(True)
 		write_connection_to_config(self.control_connector.address)
@@ -276,8 +283,10 @@ class GlobalPlugin(GlobalPlugin):
 		if kwargs['vk_code'] == win32con.VK_F11 and kwargs['pressed'] and not self.key_modified:
 			self.sending_keys = not self.sending_keys
 			if self.sending_keys:
+				# Translators: Presented when sending keyboard keys from the controlling computer to the controlled computer.
 				ui.message(_("Sending keys."))
 			else:
+				# Translators: Presented when keyboard control is back to the controlling computer.
 				ui.message(_("Not sending keys."))
 			return True #Don't pass it on
 		if not self.sending_keys:

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -72,23 +72,30 @@ class GlobalPlugin(GlobalPlugin):
 	def create_menu(self):
 		self.menu = wx.Menu()
 		tools_menu = gui.mainFrame.sysTrayIcon.toolsMenu
+		# Translators: Item in NVDA Remote submenu to connect to a remote computer.
 		self.connect_item = self.menu.Append(wx.ID_ANY, _("Connect..."), _("Remotely connect to another computer running NVDA Remote Access"))
 		gui.mainFrame.sysTrayIcon.Bind(wx.EVT_MENU, self.do_connect, self.connect_item)
+		# Translators: Item in NVDA Remote submenu to disconnect from a remote computer.
 		self.disconnect_item = self.menu.Append(wx.ID_ANY, _("Disconnect"), _("Disconnect from another computer running NVDA Remote Access"))
 		self.disconnect_item.Enable(False)
 		gui.mainFrame.sysTrayIcon.Bind(wx.EVT_MENU, self.on_disconnect_item, self.disconnect_item)
+		# Translators: Menu item in NvDA Remote submenu to mute speech from the remote computer.
 		self.mute_item = self.menu.Append(wx.ID_ANY, _("Mute remote speech"), _("Mute speech from the remote computer"))
 		self.mute_item.SetCheckable(True)
 		self.mute_item.Enable(False)
 		gui.mainFrame.sysTrayIcon.Bind(wx.EVT_MENU, self.on_mute_item, self.mute_item)
+		# Translators: Menu item in NVDA Remote submenu to push clipboard content to the remote computer.
 		self.push_clipboard_item = self.menu.Append(wx.ID_ANY, _("&Push clipboard"), _("Push the clipboard to the other machine"))
 		self.push_clipboard_item.Enable(False)
 		gui.mainFrame.sysTrayIcon.Bind(wx.EVT_MENU, self.on_push_clipboard_item, self.push_clipboard_item)
+		# Translators: Menu item in NvDA Remote submenu to open add-on options.
 		self.options_item = self.menu.Append(wx.ID_ANY, _("&Options..."), _("Options"))
 		gui.mainFrame.sysTrayIcon.Bind(wx.EVT_MENU, self.on_options_item, self.options_item)
+		# Translators: Menu item in NVDA Remote submenu to send Control+Alt+Delete to the remote computer.
 		self.send_ctrl_alt_del_item = self.menu.Append(wx.ID_ANY, _("Send Ctrl+Alt+Del"), _("Send Ctrl+Alt+Del"))
 		gui.mainFrame.sysTrayIcon.Bind(wx.EVT_MENU, self.on_send_ctrl_alt_del, self.send_ctrl_alt_del_item)
 		self.send_ctrl_alt_del_item.Enable(False)
+		# Translators: Label of menu in NVDA tools menu.
 		tools_menu.AppendSubMenu(self.menu, _("R&emote"), _("NVDA Remote Access"))
 
 
@@ -105,11 +112,13 @@ class GlobalPlugin(GlobalPlugin):
 		try:
 			connector.send(type='set_clipboard_text', text=api.getClipData())
 		except TypeError:
+			# JL: It might be helpful to provide a log.debug output for this.
 			pass
 
 	def on_options_item(self, evt):
 		evt.Skip()
 		config = get_config()
+		# Translators: The title of the add-on options dialog.
 		dlg = dialogs.OptionsDialog(gui.mainFrame, wx.ID_ANY, title=_("Options"))
 		dlg.set_from_config(config)
 		def handle_dlg_complete(dlg_result):

--- a/addon/globalPlugins/remoteClient/dialogs.py
+++ b/addon/globalPlugins/remoteClient/dialogs.py
@@ -14,12 +14,15 @@ class ClientPanel(wx.Panel):
 	def __init__(self, parent=None, id=wx.ID_ANY):
 		super(ClientPanel, self).__init__(parent, id)
 		sizer = wx.BoxSizer(wx.HORIZONTAL)
+		# Translators: The label of an edit field in connect dialog to enter name or address of the remote computer.
 		sizer.Add(wx.StaticText(self, wx.ID_ANY, label=_("&Host:")))
 		self.host = wx.TextCtrl(self, wx.ID_ANY)
 		sizer.Add(self.host)
+		# Translators: Label of the edit field to enter key (password) to secure the remote connection.
 		sizer.Add(wx.StaticText(self, wx.ID_ANY, label=_("&Key:")))
 		self.key = wx.TextCtrl(self, wx.ID_ANY)
 		sizer.Add(self.key)
+		# Translators: The button used to generate a random key/password.
 		self.generate_key = wx.Button(parent=self, label=_("&Generate Key"))
 		self.generate_key.Bind(wx.EVT_BUTTON, self.on_generate_key)
 		sizer.Add(self.generate_key)
@@ -44,9 +47,11 @@ class ServerPanel(wx.Panel):
 	def __init__(self, parent=None, id=wx.ID_ANY):
 		super(ServerPanel, self).__init__(parent, id)
 		sizer = wx.BoxSizer(wx.HORIZONTAL)
+		# Translators: Used in server mode to obtain the external IP address for the server (controlled computer) for direct connection.
 		self.get_IP = wx.Button(parent=self, label=_("Get External &IP"))
 		self.get_IP.Bind(wx.EVT_BUTTON, self.on_get_IP)
 		sizer.Add(self.get_IP)
+		# Translators: Label of the field displaying the external IP address if using direct (client to server) connection.
 		sizer.Add(wx.StaticText(self, wx.ID_ANY, label=_("&External IP:")))
 		self.external_IP = wx.TextCtrl(self, wx.ID_ANY, style=wx.TE_READONLY|wx.TE_MULTILINE)
 		sizer.Add(self.external_IP)
@@ -149,6 +154,7 @@ class OptionsDialog(wx.Dialog):
 	def __init__(self, parent, id, title):
 		super(OptionsDialog, self).__init__(parent, id, title=title)
 		main_sizer = wx.BoxSizer(wx.VERTICAL)
+		# Translators: A checkbox in add-on options dialog to set whether remote server is started when NVDA starts.
 		self.autoconnect = wx.CheckBox(self, wx.ID_ANY, label=_("Auto-connect to control server on startup"))
 		self.autoconnect.Bind(wx.EVT_CHECKBOX, self.on_autoconnect)
 		main_sizer.Add(self.autoconnect)


### PR DESCRIPTION
I've added translator comments to some strings (mostly UI-related and status messages) so translators can get an idea as to how to translate add-on messages. This prepares the add-on for localization. Thanks.
