### PR TITLE
Some features added and bugs fixed

### DIFF
--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -4,16 +4,16 @@ from cStringIO import StringIO
 import os
 import sys
 sys.path.append(os.path.abspath(os.path.dirname(__file__)))
+import json
+sys.path.remove(sys.path[-1])
 import threading
 import time
 import socket
 from globalPluginHandler import GlobalPlugin
-import json
 import logging
 logger = logging.getLogger(__name__)
 import Queue
 import select
-import config
 import configobj
 import validate
 import wx
@@ -97,8 +97,35 @@ class GlobalPlugin(GlobalPlugin):
 		gui.mainFrame.sysTrayIcon.Bind(wx.EVT_MENU, self.on_send_ctrl_alt_del, self.send_ctrl_alt_del_item)
 		self.send_ctrl_alt_del_item.Enable(False)
 		# Translators: Label of menu in NVDA tools menu.
-		tools_menu.AppendSubMenu(self.menu, _("R&emote"), _("NVDA Remote Access"))
+		self.remote_item=tools_menu.AppendSubMenu(self.menu, _("R&emote"), _("NVDA Remote Access"))
 
+	def terminate(self):
+		self.do_disconnect_from_slave(True)
+		self.local_machine = None
+		self.menu.RemoveItem(self.connect_item)
+		self.connect_item.Destroy()
+		self.connect_item=None
+		self.menu.RemoveItem(self.disconnect_item)
+		self.disconnect_item.Destroy()
+		self.disconnect_item=None
+		self.menu.RemoveItem(self.mute_item)
+		self.mute_item.Destroy()
+		self.mute_item=None
+		self.menu.RemoveItem(self.push_clipboard_item)
+		self.push_clipboard_item.Destroy()
+		self.push_clipboard_item=None
+		self.menu.RemoveItem(self.options_item)
+		self.options_item.Destroy()
+		self.options_item=None
+		self.menu.RemoveItem(self.send_ctrl_alt_del_item)
+		self.send_ctrl_alt_del_item.Destroy()
+		self.send_ctrl_alt_del_item=None
+		tools_menu = gui.mainFrame.sysTrayIcon.toolsMenu
+		tools_menu.RemoveItem(self.remote_item)
+		self.remote_item.Destroy()
+		self.remote_item=None
+		self.menu.Destroy()
+		self.menu=None
 
 	def on_disconnect_item(self, evt):
 		evt.Skip()
@@ -362,7 +389,7 @@ key = string(default="")
 def get_config():
 	global _config
 	if not _config:
-		path = os.path.join(config.getUserDefaultConfigPath(), CONFIG_FILE_NAME)
+		path = os.path.join(globalVars.appArgs.configPath, CONFIG_FILE_NAME)
 		_config = configobj.ConfigObj(path, configspec=configspec)
 		val = validate.Validator()
 		_config.validate(val, copy=True)

--- a/addon/globalPlugins/remoteClient/dialogs.py
+++ b/addon/globalPlugins/remoteClient/dialogs.py
@@ -1,4 +1,8 @@
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 import json
+sys.path.remove(sys.path[-1])
 import random
 import threading
 import urllib

--- a/addon/globalPlugins/remoteClient/serializer.py
+++ b/addon/globalPlugins/remoteClient/serializer.py
@@ -1,6 +1,9 @@
 from logging import getLogger
 log = getLogger('serializer')
+import sys
+sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 import json
+sys.path.remove(sys.path[-1])
 import speech
 
 class JSONSerializer(object):

--- a/addon/globalPlugins/remoteClient/server.py
+++ b/addon/globalPlugins/remoteClient/server.py
@@ -2,7 +2,10 @@ import os
 import select
 import socket
 import ssl
+import sys
+sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 import json
+sys.path.remove(sys.path[-1])
 import time
 
 class Server(object):
@@ -77,7 +80,11 @@ class Client(object):
 		Client.id += 1
 
 	def handle_data(self):
-		data = self.buffer + self.socket.recv(8192)
+		try:
+			data = self.buffer + self.socket.recv(8192)
+		except:
+			self.close()
+			return
 		if data == '': #Disconnect
 			self.close()
 			return
@@ -123,7 +130,10 @@ class Client(object):
 	def send(self, type, **kwargs):
 		msg = dict(type=type, **kwargs)
 		msgstr = json.dumps(msg)+"\n"
-		self.socket.sendall(msgstr)
+		try:
+			self.socket.sendall(msgstr)
+		except:
+			self.close()
 
 	def send_to_others(self, **obj):
 		for c in self.server.clients.itervalues():


### PR DESCRIPTION
Added a terminate method to clean up and free resources. Now NVDA Remote should be able to reload without restarting
NVDA.
Now the plugin path is removed from sys.path after importing json in each
module, to avoid conflicts with other addons. __init__.py, dialogs.py, server.py and serializer.py have been changed for that.
get_config(): use globalVars.appArgs.configPath instead of
config.getUserDefaultConfigPath.
server.py: handled socket errors (for example, timeout errors) that may happen in slow direct connections. If
an error is raised, the client who has the error is closed.