### PR TITLE
Handled exceptions that could happen in slow direct connections

### DIFF
--- a/addon/globalPlugins/remoteClient/server.py
+++ b/addon/globalPlugins/remoteClient/server.py
@@ -77,7 +77,11 @@ class Client(object):
 		Client.id += 1
 
 	def handle_data(self):
-		data = self.buffer + self.socket.recv(8192)
+		try:
+			data = self.buffer + self.socket.recv(8192)
+		except:
+			self.close()
+			return
 		if data == '': #Disconnect
 			self.close()
 			return
@@ -123,7 +127,10 @@ class Client(object):
 	def send(self, type, **kwargs):
 		msg = dict(type=type, **kwargs)
 		msgstr = json.dumps(msg)+"\n"
-		self.socket.sendall(msgstr)
+		try:
+			self.socket.sendall(msgstr)
+		except:
+			self.close()
 
 	def send_to_others(self, **obj):
 		for c in self.server.clients.itervalues():


### PR DESCRIPTION
I have edited the file server.py, and enclosed socket activity (send and receive) into try / except blocks. If an exception is raised, self.close() is called in the client who raised the exception. This is useful in slow connections, where timeout exceptions happen frequently.