### PR TITLE
Removed addon path after importing json

### DIFF
--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -4,11 +4,12 @@ from cStringIO import StringIO
 import os
 import sys
 sys.path.append(os.path.abspath(os.path.dirname(__file__)))
+import json
+sys.path.remove(sys.path[-1])
 import threading
 import time
 import socket
 from globalPluginHandler import GlobalPlugin
-import json
 import logging
 logger = logging.getLogger(__name__)
 import Queue

--- a/addon/globalPlugins/remoteClient/dialogs.py
+++ b/addon/globalPlugins/remoteClient/dialogs.py
@@ -1,4 +1,8 @@
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 import json
+sys.path.remove(sys.path[-1])
 import random
 import threading
 import urllib

--- a/addon/globalPlugins/remoteClient/serializer.py
+++ b/addon/globalPlugins/remoteClient/serializer.py
@@ -1,6 +1,10 @@
 from logging import getLogger
 log = getLogger('serializer')
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 import json
+sys.path.remove(sys.path[-1])
 import speech
 
 class JSONSerializer(object):

--- a/addon/globalPlugins/remoteClient/server.py
+++ b/addon/globalPlugins/remoteClient/server.py
@@ -2,7 +2,10 @@ import os
 import select
 import socket
 import ssl
+import sys
+sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 import json
+sys.path.remove(sys.path[-1])
 import time
 
 class Server(object):


### PR DESCRIPTION
To avoid conflicts with other addons, the addon path is removed from sys.path after importing json module. I have performed this operation in __init__.py, dialogs.py, serializer.py and server.py.