### PR TITLE
modified get_config function

### DIFF
--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -390,7 +390,7 @@ key = string(default="")
 def get_config():
 	global _config
 	if not _config:
-		path = os.path.join(config.getUserDefaultConfigPath(), CONFIG_FILE_NAME)
+		path = os.path.join(globalVars.appArgs.configPath, CONFIG_FILE_NAME)
 		_config = configobj.ConfigObj(path, configspec=configspec)
 		val = validate.Validator()
 		_config.validate(val, copy=True)


### PR DESCRIPTION
To match better the NVDA addon development specifications, I have changed get_config function in __init__.py. It now gets the config path from globalVars.appArgs.configPath, instead of config.getUserDefaultConfigPath()