### PR TITLE
Remove UTF-8 BOM from persian translation.

### DIFF
--- a/addon/locale/fa/LC_MESSAGES/nvda.po
+++ b/addon/locale/fa/LC_MESSAGES/nvda.po
@@ -1,4 +1,4 @@
-﻿# SOME DESCRIPTIVE TITLE.
+# SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <heidari9213@gmail.com>, YEAR.
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: 'remote' '1.0'\n"
 "Report-Msgid-Bugs-To: 'nvda-translations@freelists.org'\n"
 "POT-Creation-Date: 2015-07-04 10:32+0200\n"
-"PO-Revision-Date: 2015-07-07 22:27+0430\n"
+"PO-Revision-Date: 2015-07-12 14:06+0300\n"
 "Last-Translator: hosein heidari <heidari9213@gmail.com>\n"
 "Language-Team: hosein heidari and mohamadjavad jamshidian <heidari9213@gmail."
 "com>\n"


### PR DESCRIPTION
The byte order mark causes msgfmt to fail compiling the translation and building
 the addon to fail.  It's also useless for UTF-8 encoded files.