### PR TITLE
Catch PyDeadObjectError exception in the terminate method

### DIFF
--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -125,7 +125,10 @@ class GlobalPlugin(GlobalPlugin):
 		tools_menu.RemoveItem(self.remote_item)
 		self.remote_item.Destroy()
 		self.remote_item=None
-		self.menu.Destroy()
+		try:
+			self.menu.Destroy()
+		except wx.PyDeadObjectError:
+			pass
 		self.menu=None
 
 	def on_disconnect_item(self, evt):


### PR DESCRIPTION
Hi,

Sometimes NVDA throws PyDeadObjectError when terminating because menu object is already destroyed when NVDA Remote try to do so.
Adding a try block to pass PyDeadObjectError exception allows NVDARemote global plugin to be correctly terminated.