### PR TITLE
Gesture changes as well as new autoconnect options and an asignable status feature

### DIFF
--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -135,6 +135,10 @@ class GlobalPlugin(GlobalPlugin):
 		evt.Skip()
 		self.do_disconnect_from_slave()
 
+	def script_disconnect(self, gesture):
+		self.do_disconnect_from_slave()
+	script_disconnect.__doc__ = _("""Disconnect from a remote computer""")
+
 	def on_mute_item(self, evt):
 		evt.Skip()
 		self.local_machine.is_muted = self.mute_item.IsChecked()
@@ -144,9 +148,14 @@ class GlobalPlugin(GlobalPlugin):
 		self.mute_item.Check(self.local_machine.is_muted)
 	script_toggle_remote_mute.__doc__ = _("""Mute or unmute the speech coming from the remote computer""")
 
-	def script_on_connect(self, gesture):
-		self.do_connect('gesture')
-	script_on_connect.__doc__ = _("""Open the NVDA Remote connect dialog""")
+	def script_connect(self, gesture):
+		if self.connector or self.control_connector : # a connection is already established
+			speech.speakMessage(_("You can't open that dialog, a connection is already established"))
+		elif self.connector is None and self.control_connector is None: # A connection doesn't yet exist, open the dialog
+			self.do_connect('gesture')
+		else:
+			speech.speakMessage(_("Error, connection state can't be determined!"))
+	script_connect.__doc__ = _("""Open the NVDA Remote connect dialog if a connection isn't already established""")
 
 	def on_push_clipboard_item(self, evt):
 		connector = self.control_connector or self.connector
@@ -219,8 +228,6 @@ class GlobalPlugin(GlobalPlugin):
 			# Translators: Message shown when cannot connect to the remote computer.
 			message=_("Unable to connect to the remote computer"), style=wx.OK | wx.ICON_WARNING)
 
-	def script_disconnect(self, gesture):
-		self.do_disconnect_from_slave()
 
 	def do_connect(self, evt):
 		if evt != 'gesture':
@@ -303,7 +310,7 @@ class GlobalPlugin(GlobalPlugin):
 	def connected_to_relay(self):
 		log.info("Control connector connected")
 		beep_sequence.beep_sequence((720, 100), 50, (720, 100), 50, (720, 100))
-		# Transaltors: Presented in direct (client to server) remote connection when the controlled computer is ready.
+		# Translators: Presented in direct (client to server) remote connection when the controlled computer is ready.
 		speech.speakMessage(_("Connected to control server"))
 		self.push_clipboard_item.Enable(True)
 		write_connection_to_config(self.control_connector.address)
@@ -383,7 +390,8 @@ class GlobalPlugin(GlobalPlugin):
 		self.connect_control(('127.0.0.1', port), channel)
 
 	__gestures = {
-		"kb:alt+NVDA+pageDown": "disconnect",
+		"kb:alt+NVDA+shift+d": "disconnect",
+		"kb:NVDA+shift+c": "connect",
 	}
 
 

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -73,7 +73,8 @@ class GlobalPlugin(GlobalPlugin):
 			elif cs['autoconnect'] == 2:
 				address = address_to_hostport(cs['host'])
 			elif cs['autoconnect'] == True: # Previous version config, change value to 2 for external control server
-				cs['autoconnect'] = 2
+				config = get_config()
+				config['controlserver']['autoconnect'] = 2
 				config.write()
 			self.connect_control(address, cs['key'])
 		self.temp_location = os.path.join(shlobj.SHGetFolderPath(0, shlobj.CSIDL_COMMON_APPDATA), 'temp')

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -144,6 +144,10 @@ class GlobalPlugin(GlobalPlugin):
 		self.mute_item.Check(self.local_machine.is_muted)
 	script_toggle_remote_mute.__doc__ = _("""Mute or unmute the speech coming from the remote computer""")
 
+	def script_on_connect(self, gesture):
+		self.do_connect('gesture')
+	script_on_connect.__doc__ = _("""Open the NVDA Remote connect dialog""")
+
 	def on_push_clipboard_item(self, evt):
 		connector = self.control_connector or self.connector
 		try:
@@ -219,7 +223,8 @@ class GlobalPlugin(GlobalPlugin):
 		self.do_disconnect_from_slave()
 
 	def do_connect(self, evt):
-		evt.Skip()
+		if evt != 'gesture':
+			evt.Skip()
 		last_cons = get_config()['connections']['last_connected']
 		last = ''
 		if last_cons:

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -64,7 +64,17 @@ class GlobalPlugin(GlobalPlugin):
 		self.sd_server = None
 		cs = get_config()['controlserver']
 		if cs['autoconnect']:
-			address = address_to_hostport(cs['host'])
+			if cs['autoconnect'] == '1': # self-hosted server
+				self.server = server.Server(SERVER_PORT, cs['key'])
+				server_thread = threading.Thread(target=self.server.run)
+				server_thread.daemon = True
+				server_thread.start()
+				address = address_to_hostport('localhost')
+			elif cs['autoconnect'] == 2:
+				address = address_to_hostport(cs['host'])
+			elif cs['autoconnect'] == True: # Previous version config, change value to 2 for external control server
+				cs['autoconnect'] = 2
+				config.write()
 			self.connect_control(address, cs['key'])
 		self.temp_location = os.path.join(shlobj.SHGetFolderPath(0, shlobj.CSIDL_COMMON_APPDATA), 'temp')
 		self.ipc_file = os.path.join(self.temp_location, 'remote.ipc')

--- a/addon/globalPlugins/remoteClient/dialogs.py
+++ b/addon/globalPlugins/remoteClient/dialogs.py
@@ -161,10 +161,7 @@ class OptionsDialog(wx.Dialog):
 		super(OptionsDialog, self).__init__(parent, id, title=title)
 		main_sizer = wx.BoxSizer(wx.VERTICAL)
 		# Translators: A radiobutton group in add-on options dialog to choose if autoconnecting is disabled, connects to a self-hosted server, or to an external control server, in that order.
-		self.autoconnect= wx.RadioBox(self, wx.ID_ANY, choices=(_("Don't autoconnect"), _("Autoconnect to a self-hosted server"), _("Autoconnect to an external control server")), style=wx.RA_VERTICAL)
-#		self.autoconnect.SetSelection(0)
-
-#		self.autoconnect = wx.CheckBox(self, wx.ID_ANY, label=_("Auto-connect to control server on startup"))
+		self.autoconnect = wx.RadioBox(self, wx.ID_ANY, choices=(_("Don't autoconnect"), _("Autoconnect to a self-hosted server"), _("Autoconnect to an external control server")), style=wx.RA_VERTICAL)
 		self.autoconnect.Bind(wx.EVT_RADIOBOX, self.on_autoconnect)
 		main_sizer.Add(self.autoconnect)
 		main_sizer.Add(wx.StaticText(self, wx.ID_ANY, label=_("&Host:")))
@@ -187,7 +184,7 @@ class OptionsDialog(wx.Dialog):
 		self.set_controls()
 
 	def set_controls(self):
-		state = self.autoconnect.GetValue()
+		state = self.autoconnect.GetSelection()
 		if state == 0: # if autoconnect is disabled
 			self.host.Enable(False)
 			self.key.Enable(False)
@@ -202,20 +199,24 @@ class OptionsDialog(wx.Dialog):
 
 	def set_from_config(self, config):
 		cs = config['controlserver']
-		self.autoconnect.SetValue(cs['autoconnect'])
+		if cs['autoconnect'] == True:
+			cs['autoconnect'] = int(2)
+		elif cs['autoconnect'] == False:
+			cs['autoconnect'] = int(0)
+		self.autoconnect.SetSelection(cs['autoconnect'])
 		self.host.SetValue(cs['host'])
 		self.key.SetValue(cs['key'])
 		self.set_controls()
 
 	def on_ok(self, evt):
-		if self.autoconnect.GetValue() and (self.autoconnect not 1 and not self.host.GetValue() or not self.key.GetValue()):
+		if self.autoconnect.GetSelection() and (self.autoconnect !=1 and not self.host.GetValue() or not self.key.GetValue()):
 			gui.messageBox(_("Both host and key must be set."), _("Error"), wx.OK | wx.ICON_ERROR)
 		else:
 			evt.Skip()
 
 	def write_to_config(self, config):
 		cs = config['controlserver']
-		cs['autoconnect'] = self.autoconnect.GetValue()
+		cs['autoconnect'] = self.autoconnect.GetSelection()
 		cs['host'] = self.host.GetValue()
 		cs['key'] = self.key.GetValue()
 		config.write()

--- a/addon/globalPlugins/remoteClient/dialogs.py
+++ b/addon/globalPlugins/remoteClient/dialogs.py
@@ -203,7 +203,7 @@ class OptionsDialog(wx.Dialog):
 			cs['autoconnect'] = int(2)
 		elif cs['autoconnect'] == False:
 			cs['autoconnect'] = int(0)
-		self.autoconnect.SetSelection(cs['autoconnect'])
+		self.autoconnect.SetSelection(int(cs['autoconnect']))
 		self.host.SetValue(cs['host'])
 		self.key.SetValue(cs['key'])
 		self.set_controls()

--- a/addon/globalPlugins/remoteClient/dialogs.py
+++ b/addon/globalPlugins/remoteClient/dialogs.py
@@ -160,9 +160,12 @@ class OptionsDialog(wx.Dialog):
 	def __init__(self, parent, id, title):
 		super(OptionsDialog, self).__init__(parent, id, title=title)
 		main_sizer = wx.BoxSizer(wx.VERTICAL)
-		# Translators: A checkbox in add-on options dialog to set whether remote server is started when NVDA starts.
-		self.autoconnect = wx.CheckBox(self, wx.ID_ANY, label=_("Auto-connect to control server on startup"))
-		self.autoconnect.Bind(wx.EVT_CHECKBOX, self.on_autoconnect)
+		# Translators: A radiobutton group in add-on options dialog to choose if autoconnecting is disabled, connects to a self-hosted server, or to an external control server, in that order.
+		self.autoconnect= wx.RadioBox(self, wx.ID_ANY, choices=(_("Don't autoconnect"), _("Autoconnect to a self-hosted server"), _("Autoconnect to an external control server")), style=wx.RA_VERTICAL)
+#		self.autoconnect.SetSelection(0)
+
+#		self.autoconnect = wx.CheckBox(self, wx.ID_ANY, label=_("Auto-connect to control server on startup"))
+		self.autoconnect.Bind(wx.EVT_RADIOBOX, self.on_autoconnect)
 		main_sizer.Add(self.autoconnect)
 		main_sizer.Add(wx.StaticText(self, wx.ID_ANY, label=_("&Host:")))
 		self.host = wx.TextCtrl(self, wx.ID_ANY)
@@ -185,8 +188,17 @@ class OptionsDialog(wx.Dialog):
 
 	def set_controls(self):
 		state = self.autoconnect.GetValue()
-		self.host.Enable(state)
-		self.key.Enable(state)
+		if state == 0: # if autoconnect is disabled
+			self.host.Enable(False)
+			self.key.Enable(False)
+		elif state == 1:# if autoconnect is set to connect to a self-hosted server
+			self.host.Enable(False) # no need for the user to set the host
+			self.key.Enable(True)
+		elif state == 2: # if autoconnect is set to connect to an external control server
+			self.host.Enable(True)
+			self.key.Enable(True)
+		else: # the state is unknown, possibly an old bool value, disable
+			self.autoconnect.SetValue(0)
 
 	def set_from_config(self, config):
 		cs = config['controlserver']
@@ -196,7 +208,7 @@ class OptionsDialog(wx.Dialog):
 		self.set_controls()
 
 	def on_ok(self, evt):
-		if self.autoconnect.GetValue() and (not self.host.GetValue() or not self.key.GetValue()):
+		if self.autoconnect.GetValue() and (self.autoconnect not 1 and not self.host.GetValue() or not self.key.GetValue()):
 			gui.messageBox(_("Both host and key must be set."), _("Error"), wx.OK | wx.ICON_ERROR)
 		else:
 			evt.Skip()

--- a/addon/globalPlugins/remoteClient/dialogs.py
+++ b/addon/globalPlugins/remoteClient/dialogs.py
@@ -199,10 +199,6 @@ class OptionsDialog(wx.Dialog):
 
 	def set_from_config(self, config):
 		cs = config['controlserver']
-		if cs['autoconnect'] == True:
-			cs['autoconnect'] = int(2)
-		elif cs['autoconnect'] == False:
-			cs['autoconnect'] = int(0)
 		self.autoconnect.SetSelection(int(cs['autoconnect']))
 		self.host.SetValue(cs['host'])
 		self.key.SetValue(cs['key'])


### PR DESCRIPTION
In the gesture-changes branch, I've added and changed the following:  
* redesigned autoconnect:
  * Don't autoconnect
  * Autoconnect to a self-hosted server: Start a local NVDA Remote server on this machine and connect to it, ready to be controlled. This has the advantage of being not only more secure (users don't have to leave an open connection to a server they don't own), but it can be used in environments cut off from the internet or behind restrictive company firewalls.
  * Autoconnect to an external control server: just what autoconnect did before
* Added a configurable gesture / hotkey to open the connect dialog (through NVDA Gestures)
* Fixed the existing disconnect gesture, it now shows up in NVDA along with the others
* Added a status function, it doesn't have a hotkey assigned by default
