### PR TITLE
Braille implementation for NVDA Remote

### DIFF
--- a/addon/doc/en/readme.md
+++ b/addon/doc/en/readme.md
@@ -46,7 +46,7 @@ When the other person connects, you can use NVDA Remote normally.
 
 ##Sending keys
 Once the session is connected, the controlling machine can then press f11 to start sending keys.
-When NVDA says sending keys, the keys you press will go to the remote machine. Press f11 again to stop sending keys and switch back to the controlling machine.
+When NVDA says sending keys, the keyboard and braille display keys you press will go to the remote machine. Furthermore, when the controlling machine is using a braille display, information from the remote machine will be displayed on it. Press f11 again to stop sending keys and switch back to the controlling machine.
 For best compatibility, please ensure that the keyboard layouts on both machines match.
 
 ##Send Ctrl+Alt+Del
@@ -70,14 +70,14 @@ Note: The autoconnect at startup-related options in the options dialog do not ap
 
 
 ##Muting Speech on the Remote Computer
-If you do not wish to hear the remote computer's speech, simply access the NVDA menu, Tools, and Remote. Arrow down to Mute Remote Speech, and press Enter.
+If you do not wish to hear the remote computer's speech or NVDA specific sounds, simply access the NVDA menu, Tools, and Remote. Arrow down to Mute Remote, and press Enter. Please note that this option will not disable remote braille output to the controlling display when the controlling machine is sending keys.
 
 
 ##Ending a remote Session
 
 To end a remote session, do the following:
 
-1. On the controlling computer, press F11 to stop sending keys. You should hear the message: "Not sending keys." If you instead hear a message that you are sending keys, press F11 once more.
+1. On the controlling computer, press F11 to stop sending keys. You should hear or read the message: "Not sending keys." If you instead hear or read a message that you are sending keys, press F11 once more.
 
 2. Access the NVDA menu, then Tools, Remote, and press Enter on Disconnect.
 
@@ -97,7 +97,7 @@ In order for NVDA Remote to work on the secure desktop, the addon must be instal
 4. When settings are copied, press Enter to dismiss the OK button. Tab to OK and Enter once more to exit the dialog.
 
 Once NVDA Remote is installed on the secure desktop, if you are currently being controlled in a remote session,
-the secure desktop will read when switched to.
+you will have speech and braille access to the secure desktop when switched to.
 
 ##Contributions
 We would like to acknowledge the following contributors, among others, who helped make the NVDA Remote project a reality.
@@ -113,3 +113,5 @@ We would like to acknowledge the following contributors, among others, who helpe
 * ABDULAZIZ ALSHMASI.
 * Tyler W Kavanaugh
 * Casey Mathews
+* Babbage B.V.
+* Leonard de Ruijter

--- a/addon/doc/en/readme.md
+++ b/addon/doc/en/readme.md
@@ -44,9 +44,9 @@ Enter a key into the key field, or press generate. The other person will need yo
 Once ok is pressed, you will be connected.
 When the other person connects, you can use NVDA Remote normally.
 
-##Sending keys
-Once the session is connected, the controlling machine can then press f11 to start sending keys.
-When NVDA says sending keys, the keyboard and braille display keys you press will go to the remote machine. Furthermore, when the controlling machine is using a braille display, information from the remote machine will be displayed on it. Press f11 again to stop sending keys and switch back to the controlling machine.
+##Controlling remote machine
+Once the session is connected, the controlling machine can then press f11 to start controlling the remote machine (e.g. by sending keyboard keys or braille input).
+When NVDA says controlling remote machine, the keyboard and braille display keys you press will go to the remote machine. Furthermore, when the controlling machine is using a braille display, information from the remote machine will be displayed on it. Press f11 again to stop sending keys and switch back to the controlling machine.
 For best compatibility, please ensure that the keyboard layouts on both machines match.
 
 ##Send Ctrl+Alt+Del
@@ -77,7 +77,7 @@ If you do not wish to hear the remote computer's speech or NVDA specific sounds,
 
 To end a remote session, do the following:
 
-1. On the controlling computer, press F11 to stop sending keys. You should hear or read the message: "Not sending keys." If you instead hear or read a message that you are sending keys, press F11 once more.
+1. On the controlling computer, press F11 to stop controlling the remote machine. You should hear or read the message: "Controlling local machine." If you instead hear or read a message that you are controlling the remote machine, press F11 once more.
 
 2. Access the NVDA menu, then Tools, Remote, and press Enter on Disconnect.
 

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -343,14 +343,14 @@ class GlobalPlugin(GlobalPlugin):
 			self.sending_keys = False
 			self.set_receiving_braille(False)
 			# Translators: Presented when keyboard control is back to the controlling computer.
-			ui.message(_("Not sending keys."))
+			ui.message(_("Controlling local machine."))
 			return True #Don't pass it on
 		self.master_transport.send(type="key", **kwargs)
 		return True #Don't pass it on
 
 	def script_sendKeys(self, gesture):
 		# Translators: Presented when sending keyboard keys from the controlling computer to the controlled computer.
-		ui.message(_("Sending keys."))
+		ui.message(_("Controlling remote machine."))
 		self.sending_keys = True
 		self.set_receiving_braille(True)
 

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -419,7 +419,6 @@ class GlobalPlugin(GlobalPlugin):
 
 	def on_master_display_change(self, **kwargs):
 		self.sd_relay.send(type='set_display_size', sizes=self.slave_session.master_display_sizes)
->>>>>>> Braille support for NVDA Remote, based on the new protocol version 2 implmentation. Implemented on behalf of @BabbageCom.
 
 	def handle_secure_desktop(self):
 		try:

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -22,6 +22,7 @@ import gui
 import beep_sequence
 import speech
 from transport import RelayTransport
+import braille
 import local_machine
 import serializer
 from session import MasterSession, SlaveSession
@@ -340,6 +341,7 @@ class GlobalPlugin(GlobalPlugin):
 			self.key_modified = kwargs['pressed']
 		if kwargs['vk_code'] == win32con.VK_F11 and kwargs['pressed'] and not self.key_modified:
 			self.sending_keys = False
+			self.set_receiving_braille(False)
 			# Translators: Presented when keyboard control is back to the controlling computer.
 			ui.message(_("Not sending keys."))
 			return True #Don't pass it on
@@ -350,6 +352,25 @@ class GlobalPlugin(GlobalPlugin):
 		# Translators: Presented when sending keyboard keys from the controlling computer to the controlled computer.
 		ui.message(_("Sending keys."))
 		self.sending_keys = True
+		self.set_receiving_braille(True)
+
+	def set_receiving_braille(self, state):
+		if state and self.master_session.patch_callbacks_added and braille.handler.enabled:
+			self.master_session.patcher.patch_braille_input()
+			braille.handler.enabled = False
+			if braille.handler._cursorBlinkTimer:
+				braille.handler._cursorBlinkTimer.Stop()
+				braille.handler._cursorBlinkTimer=None
+			if braille.handler.buffer is braille.handler.messageBuffer:
+				braille.handler.buffer.clear()
+				braille.handler.buffer = braille.handler.mainBuffer
+				braille.handler._messageCallLater.Stop()
+				braille.handler._messageCallLater = None
+			self.local_machine.receiving_braille=True
+		elif not state:
+			self.master_session.patcher.unpatch_braille_input()
+			braille.handler.enabled = bool(braille.handler.displaySize)
+			self.local_machine.receiving_braille=False
 
 	def event_gainFocus(self, obj, nextHandler):
 		if isinstance(obj, IAccessibleHandler.SecureDesktopNVDAObject):
@@ -374,6 +395,8 @@ class GlobalPlugin(GlobalPlugin):
 		server_thread.daemon = True
 		server_thread.start()
 		self.sd_relay = RelayTransport(address=('127.0.0.1', port), serializer=serializer.JSONSerializer(), channel=channel)
+		self.sd_relay.callback_manager.register_callback('msg_client_joined', self.on_master_display_change)
+		self.slave_transport.callback_manager.register_callback('msg_set_braille_info', self.on_master_display_change)
 		self.sd_bridge = bridge.BridgeTransport(self.slave_transport, self.sd_relay)
 		relay_thread = threading.Thread(target=self.sd_relay.run)
 		relay_thread.daemon = True
@@ -391,6 +414,12 @@ class GlobalPlugin(GlobalPlugin):
 		self.sd_server = None
 		self.sd_relay.close()
 		self.sd_relay = None
+		self.slave_transport.callback_manager.unregister_callback('msg_set_braille_info', self.on_master_display_change)
+		self.slave_session.set_display_size()
+
+	def on_master_display_change(self, **kwargs):
+		self.sd_relay.send(type='set_display_size', sizes=self.slave_session.master_display_sizes)
+>>>>>>> Braille support for NVDA Remote, based on the new protocol version 2 implmentation. Implemented on behalf of @BabbageCom.
 
 	def handle_secure_desktop(self):
 		try:

--- a/addon/globalPlugins/remoteClient/bridge.py
+++ b/addon/globalPlugins/remoteClient/bridge.py
@@ -2,7 +2,7 @@ class BridgeTransport(object):
 	"""Object to bridge two transports together,
 	passing messages to both of them.
 	We exclude transport-specific messages such as client_joined."""
-	excluded = ('client_joined', 'client_left', 'channel_joined')
+	excluded = ('client_joined', 'client_left', 'channel_joined', 'set_braille_info')
 
 	def __init__(self, t1, t2):
 		self.t1 = t1

--- a/addon/globalPlugins/remoteClient/local_machine.py
+++ b/addon/globalPlugins/remoteClient/local_machine.py
@@ -5,9 +5,9 @@ import api
 import nvwave
 import tones
 import speech
-import nvda_patcher
 import ctypes
-
+import braille
+import inputCore
 import logging
 logger = logging.getLogger('local_machine')
 
@@ -15,8 +15,8 @@ class LocalMachine(object):
 
 	def __init__(self):
 		self.is_muted = False
-		self.patcher = nvda_patcher.NVDAPatcher()
-
+		self.receiving_braille=False
+		
 	def play_wave(self, fileName, async, **kwargs):
 		if self.is_muted:
 			return
@@ -40,6 +40,27 @@ class LocalMachine(object):
 		synth = speech.getSynth()
 		speech.beenCanceled = False
 		wx.CallAfter(synth.speak, sequence)
+
+	def display(self, cells, **kwargs):
+		if self.receiving_braille and braille.handler.display.numCells>0 and len(cells)<=braille.handler.display.numCells:
+			# We use braille.handler._writeCells since this respects thread safe displays and automatically falls back to noBraille if desired
+			cells = cells + [0] * (braille.handler.displaySize - len(cells))
+			wx.CallAfter(braille.handler._writeCells, cells)
+
+	def braille_input(self, **kwargs):
+		try:
+			inputCore.manager.executeGesture(input.BrailleInputGesture(**kwargs))
+		except inputCore.NoInputGestureAction:
+			pass
+
+	def set_braille_display_size(self, sizes, **kwargs):
+		sizes.append(braille.handler.display.numCells)
+		try:
+			size=min(i for i in sizes if i>0)
+		except ValueError:
+			size=braille.handler.display.numCells
+		braille.handler.displaySize=size
+		braille.handler.enabled = bool(size)
 
 	def send_key(self, vk_code=None, extended=None, pressed=None, **kwargs):
 		wx.CallAfter(input.send_key, vk_code, None, extended, pressed)

--- a/addon/globalPlugins/remoteClient/nvda_patcher.py
+++ b/addon/globalPlugins/remoteClient/nvda_patcher.py
@@ -4,12 +4,47 @@ import tones
 import nvwave
 import gui
 import speech
+import inputCore
+import braille
+import brailleInput
+import scriptHandler
 
 class NVDAPatcher(callback_manager.CallbackManager):
-	"""Class to manage patching of synth, tones, and nvwave."""
+	"""Base class to manage patching of braille display changes."""
 
 	def __init__(self):
 		super(NVDAPatcher, self).__init__()
+		self.orig_setDisplayByName = None
+
+	def patch_set_display(self):
+		if self.orig_setDisplayByName is not None:
+			return
+		self.orig_setDisplayByName = braille.handler.setDisplayByName
+		braille.handler.setDisplayByName = self.setDisplayByName
+
+	def unpatch_set_display(self):
+		if self.orig_setDisplayByName is None:
+			return
+		braille.handler.setDisplayByName = self.orig_setDisplayByName
+		self.orig_setDisplayByName = None
+
+	def patch(self):
+		self.patch_set_display()
+
+	def unpatch(self):
+		self.unpatch_set_display()
+
+	def setDisplayByName(self, name, isFallback=False):
+		result=self.orig_setDisplayByName(name,isFallback)
+		if result:
+			self.call_callbacks('set_display')
+		return result
+
+class NVDASlavePatcher(NVDAPatcher):
+	"""Class to manage patching of synth, tones, nvwave, and braille."""
+
+	def __init__(self):
+		super(NVDASlavePatcher, self).__init__()
 		self.orig_speak = None
 		self.orig_cancel = None
 		self.orig_get_lastIndex  = None
@@ -17,6 +52,7 @@ class NVDAPatcher(callback_manager.CallbackManager):
 		self.orig_setSynth  = None
 		self.orig_beep = None
 		self.orig_playWaveFile = None
+		self.orig_display = None
 
 	def patch_synth(self):
 		if self.orig_setSynth  is not None:
@@ -53,6 +89,12 @@ class NVDAPatcher(callback_manager.CallbackManager):
 		self.orig_playWaveFile = nvwave.playWaveFile
 		nvwave.playWaveFile = self.playWaveFile
 
+	def patch_braille(self):
+		if self.orig_display is not None:
+			return
+		self.orig_display = braille.handler._writeCells
+		braille.handler._writeCells = self.display
+
 	def unpatch_synth(self):
 		if self.orig_setSynth  is None:
 			return
@@ -85,15 +127,27 @@ class NVDAPatcher(callback_manager.CallbackManager):
 		nvwave.playWaveFile = self.orig_playWaveFile
 		self.orig_playWaveFile = None
 
+	def unpatch_braille(self):
+		if self.orig_display is None:
+			return
+		braille.handler._writeCells = self.orig_display
+		self.orig_display = None
+		braille.handler.displaySize=braille.handler.display.numCells
+		braille.handler.enabled = bool(braille.handler.displaySize)
+
 	def patch(self):
+		super(NVDASlavePatcher, self).patch()
 		self.patch_synth()
 		self.patch_tones()
 		self.patch_nvwave()
+		self.patch_braille()
 
 	def unpatch(self):
+		super(NVDASlavePatcher, self).unpatch()
 		self.unpatch_synth()
 		self.unpatch_tones()
 		self.unpatch_nvwave()
+		self.unpatch_braille()
 
 	def speak(self, speechSequence):
 		self.call_callbacks('speak', speechSequence=speechSequence)
@@ -118,8 +172,80 @@ class NVDAPatcher(callback_manager.CallbackManager):
 		self.call_callbacks('wave', fileName=fileName, async=async)
 		return self.orig_playWaveFile(fileName, async=async)
 
+	def display(self, cells):
+		self.call_callbacks('display', cells=cells)
+		self.orig_display(cells)
+
 	def _get_lastIndex(self, instance):
 		return self.last_index_callback()
 
 	def set_last_index_callback(self, callback):
 		self.last_index_callback = callback
+
+class NVDAMasterPatcher(NVDAPatcher):
+	"""Class to manage patching of braille input."""
+
+	def __init__(self):
+		super(NVDAMasterPatcher, self).__init__()
+		self.orig_executeGesture = None
+
+	def patch_braille_input(self):
+		if self.orig_executeGesture is not None:
+			return
+		self.orig_executeGesture = inputCore.manager.executeGesture
+		inputCore.manager.executeGesture= self.executeGesture
+
+	def unpatch_braille_input(self):
+		if self.orig_executeGesture is None:
+			return
+		inputCore.manager.executeGesture = self.orig_executeGesture
+		self.orig_executeGesture = None
+
+	def patch(self):
+		super(NVDAMasterPatcher, self).patch()
+		# We do not patch braille input by default
+
+	def unpatch(self):
+		super(NVDAMasterPatcher, self).unpatch()
+		# To be sure, unpatch braille input
+		self.unpatch_braille_input()
+
+	def executeGesture(self, gesture):
+		if isinstance(gesture,(braille.BrailleDisplayGesture,brailleInput.BrailleInputGesture)):
+			dict = { key: gesture.__dict__[key] for key in gesture.__dict__ if isinstance(gesture.__dict__[key],(int,str,bool))}
+			if gesture.script:
+				name=scriptHandler.getScriptName(gesture.script)
+				if name.startswith("kb"):
+					location=['globalCommands', 'GlobalCommands']
+				else:
+					location=scriptHandler.getScriptLocation(gesture.script).rsplit(".",1)
+				dict["scriptPath"]=location+[name]
+			else:
+				scriptData=None
+				maps=[inputCore.manager.userGestureMap,inputCore.manager.localeGestureMap]
+				if braille.handler.display.gestureMap:
+					maps.append(braille.handler.display.gestureMap)
+				for map in maps:
+					for identifier in gesture.identifiers:
+						try:
+							scriptData=next(map.getScriptsForGesture(identifier))
+							break
+						except StopIteration:
+							continue
+				if scriptData:
+					dict["scriptPath"]=[scriptData[0].__module__,scriptData[0].__name__,scriptData[1]]
+			if hasattr(gesture,"source") and "source" not in dict:
+				dict["source"]=gesture.source
+			if hasattr(gesture,"id") and "id" not in dict:
+				dict["id"]=gesture.id
+			elif hasattr(gesture,"identifiers") and "identifiers" not in dict:
+				dict["identifiers"]=gesture.identifiers
+			if hasattr(gesture,"dots") and "dots" not in dict:
+				dict["dots"]=gesture.dots
+			if hasattr(gesture,"space") and "space" not in dict:
+				dict["space"]=gesture.space
+			if hasattr(gesture,"routingIndex") and "routingIndex" not in dict:
+				dict["routingIndex"]=gesture.routingIndex
+			self.call_callbacks('braille_input', **dict)
+		else:
+			self.orig_executeGesture(gesture)

--- a/addon/globalPlugins/remoteClient/session.py
+++ b/addon/globalPlugins/remoteClient/session.py
@@ -115,7 +115,7 @@ class SlaveSession(RemoteSession):
 
 	def display(self, cells):
 		# Only send braille data when there are controlling machines with a braille display
-		if self.has_vraille_masters():
+		if self.has_braille_masters():
 			self.transport.send(type="display", cells=cells)
 
 	def has_braille_masters(self):

--- a/addon/globalPlugins/remoteClient/session.py
+++ b/addon/globalPlugins/remoteClient/session.py
@@ -3,11 +3,15 @@ import time
 import speech
 import ui
 import tones
+import braille
+import nvda_patcher
+from collections import defaultdict
 
 class RemoteSession(object):
 
 	def __init__(self, local_machine, transport):
 		self.local_machine = local_machine
+		self.patcher = None
 		self.transport = transport
 		self.transport.callback_manager.register_callback('msg_version_mismatch', self.handle_version_mismatch)
 
@@ -18,7 +22,7 @@ Please either use a different server or upgrade your version of the addon.""")
 		ui.message(message)
 		self.transport.close()
 
-class SlaveSession(RemoteSession):
+class SlaveSession(RemoteSession):	
 	"""Session that runs on the slave and manages state."""
 
 	def __init__(self, *args, **kwargs):
@@ -26,23 +30,28 @@ class SlaveSession(RemoteSession):
 		self.transport.callback_manager.register_callback('msg_client_joined', self.handle_client_connected)
 		self.transport.callback_manager.register_callback('msg_client_left', self.handle_client_disconnected)
 		self.transport.callback_manager.register_callback('msg_key', self.local_machine.send_key)
-		self.masters = {}
+		self.masters = defaultdict(dict)
+		self.master_display_sizes=[]
 		self.last_client_index = None
 		self.transport.callback_manager.register_callback('msg_index', self.update_index)
 		self.transport.callback_manager.register_callback('transport_closing', self.handle_transport_closing)
+		self.patcher = nvda_patcher.NVDASlavePatcher()
 		self.patch_callbacks_added = False
 		self.transport.callback_manager.register_callback('msg_channel_joined', self.handle_channel_joined)
 		self.transport.callback_manager.register_callback('msg_set_clipboard_text', self.local_machine.set_clipboard_text)
+		self.transport.callback_manager.register_callback('msg_set_braille_info', self.handle_braille_info)
+		self.transport.callback_manager.register_callback('msg_set_display_size', self.set_display_size)
+		self.transport.callback_manager.register_callback('msg_braille_input', self.local_machine.braille_input)
 		self.transport.callback_manager.register_callback('msg_send_SAS', self.local_machine.send_SAS)
 
 	def handle_client_connected(self, client=None, **kwargs):
-		self.local_machine.patcher.patch()
+		self.patcher.patch()
 		if not self.patch_callbacks_added:
 			self.add_patch_callbacks()
 			self.patch_callbacks_added = True
-		self.local_machine.patcher.orig_beep(1000, 300)
+		self.patcher.orig_beep(1000, 300)
 		if client['connection_type'] == 'master':
-			self.masters[client['id']] = True
+			self.masters[client['id']]['active'] = True
 
 	def handle_channel_joined(self, channel=None, clients=None, origin=None, **kwargs):
 		if clients is None:
@@ -51,32 +60,43 @@ class SlaveSession(RemoteSession):
 			self.handle_client_connected(client)
 
 	def handle_transport_closing(self):
-		self.local_machine.patcher.unpatch()
+		self.patcher.unpatch()
 		if self.patch_callbacks_added:
 			self.remove_patch_callbacks()
 			self.patch_callbacks_added = False
 
 	def handle_transport_disconnected(self):
-		self.local_machine.patcher.orig_beep(1000, 300)
-		self.local_machine.patcher.unpatch()
+		self.patcher.orig_beep(1000, 300)
+		self.patcher.unpatch()
 
 	def handle_client_disconnected(self, client=None, **kwargs):
-		self.local_machine.patcher.orig_beep(108, 300)
+		self.patcher.orig_beep(108, 300)
 		if not self.masters:
-			self.local_machine.patcher.unpatch()
+			self.patcher.unpatch()
 		if client['connection_type'] == 'master':
 			del self.masters[client['id']]
 
+	def set_display_size(self, sizes=None, **kwargs):
+		self.master_display_sizes = sizes if sizes else [info.get("braille_numCells", 0) for info in self.masters.itervalues()]
+		self.local_machine.set_braille_display_size(self.master_display_sizes)
+
+	def handle_braille_info(self, name=None, numCells=0, origin=None, **kwargs):
+		if not self.masters.get(origin):
+			return
+		self.masters[origin]['braille_name'] = name
+		self.masters[origin]['braille_numCells'] = numCells
+		self.set_display_size()
+
 	def add_patch_callbacks(self):
-		patcher_callbacks = (('speak', self.speak), ('beep', self.beep), ('wave', self.playWaveFile), ('cancel_speech', self.cancel_speech))
+		patcher_callbacks = (('speak', self.speak), ('beep', self.beep), ('wave', self.playWaveFile), ('cancel_speech', self.cancel_speech), ('display', self.display), ('set_display', self.set_display_size))
 		for event, callback in patcher_callbacks:
-			self.local_machine.patcher.register_callback(event, callback)
-		self.local_machine.patcher.set_last_index_callback(self._get_lastIndex)
+			self.patcher.register_callback(event, callback)
+		self.patcher.set_last_index_callback(self._get_lastIndex)
 
 	def remove_patch_callbacks(self):
-		patcher_callbacks = (('speak', self.speak), ('beep', self.beep), ('wave', self.playWaveFile), ('cancel_speech', self.cancel_speech))
+		patcher_callbacks = (('speak', self.speak), ('beep', self.beep), ('wave', self.playWaveFile), ('cancel_speech', self.cancel_speech), ('display', self.display), ('set_display', self.set_display_size))
 		for event, callback in patcher_callbacks:
-			self.local_machine.patcher.unregister_callback(event, callback)
+			self.patcher.unregister_callback(event, callback)
 
 	def speak(self, speechSequence):
 		self.transport.send(type="speak", sequence=speechSequence)
@@ -93,6 +113,11 @@ class SlaveSession(RemoteSession):
 	def playWaveFile(self, fileName, async=True):
 		self.transport.send(type='wave', fileName=fileName, async=async)
 
+	def display(self, cells):
+		# Only send braille data when there are controlling machines with a braille display
+		if [i for i in self.master_display_sizes if i>0]:
+			self.transport.send(type="display", cells=cells)
+
 	def update_index(self, index=None, **kwargs):
 		self.last_client_index = index
 
@@ -100,17 +125,21 @@ class MasterSession(RemoteSession):
 
 	def __init__(self, *args, **kwargs):
 		super(MasterSession, self).__init__(*args, **kwargs)
-		self.slaves = []
+		self.slaves = defaultdict(dict)
 		self.index_thread = None
+		self.patcher = nvda_patcher.NVDAMasterPatcher()
+		self.patch_callbacks_added = False
 		self.transport.callback_manager.register_callback('msg_speak', self.local_machine.speak)
 		self.transport.callback_manager.register_callback('msg_cancel', self.local_machine.cancel_speech)
 		self.transport.callback_manager.register_callback('msg_tone', self.local_machine.beep)
 		self.transport.callback_manager.register_callback('msg_wave', self.local_machine.play_wave)
+		self.transport.callback_manager.register_callback('msg_display', self.local_machine.display)
 		self.transport.callback_manager.register_callback('msg_nvda_not_connected', self.handle_nvda_not_connected)
 		self.transport.callback_manager.register_callback('msg_client_joined', self.handle_client_connected)
 		self.transport.callback_manager.register_callback('msg_client_left', self.handle_client_disconnected)
 		self.transport.callback_manager.register_callback('msg_channel_joined', self.handle_channel_joined)
 		self.transport.callback_manager.register_callback('msg_set_clipboard_text', self.local_machine.set_clipboard_text)
+		self.transport.callback_manager.register_callback('msg_send_braille_info', self.send_braille_info)
 		self.transport.callback_manager.register_callback('transport_connected', self.handle_connected)
 		self.transport.callback_manager.register_callback('transport_disconnected', self.handle_disconnected)
 
@@ -129,14 +158,32 @@ class MasterSession(RemoteSession):
 		self.index_thread = None
 
 	def handle_channel_joined(self, channel=None, clients=None, origin=None, **kwargs):
+		if clients is None:
+			clients = []
 		for client in clients:
 			self.handle_client_connected(client)
 
 	def handle_client_connected(self, client=None, **kwargs):
+		self.patcher.patch()
+		if not self.patch_callbacks_added:
+			self.add_patch_callbacks()
+			self.patch_callbacks_added = True
+		self.send_braille_info()
 		tones.beep(1000, 300)
 
 	def handle_client_disconnected(self, client=None, **kwargs):
+		self.patcher.unpatch()
+		if self.patch_callbacks_added:
+			self.remove_patch_callbacks()
+			self.patch_callbacks_added = False
 		tones.beep(108, 300)
+
+	def send_braille_info(self):
+		display=braille.handler.display
+		self.transport.send(type="set_braille_info", name=display.name, numCells=display.numCells)
+
+	def braille_input(self,**kwargs):
+		self.transport.send(type="braille_input", **kwargs)
 
 	def send_indexes(self):
 		last = None
@@ -152,3 +199,12 @@ class MasterSession(RemoteSession):
 				last = index
 			time.sleep(POLL_TIME)
 
+	def add_patch_callbacks(self):
+		patcher_callbacks = (('braille_input', self.braille_input), ('set_display', self.send_braille_info))
+		for event, callback in patcher_callbacks:
+			self.patcher.register_callback(event, callback)
+
+	def remove_patch_callbacks(self):
+		patcher_callbacks = (('braille_input', self.braille_input), ('set_display', self.send_braille_info))
+		for event, callback in patcher_callbacks:
+			self.patcher.unregister_callback(event, callback)

--- a/addon/globalPlugins/remoteClient/session.py
+++ b/addon/globalPlugins/remoteClient/session.py
@@ -115,8 +115,11 @@ class SlaveSession(RemoteSession):
 
 	def display(self, cells):
 		# Only send braille data when there are controlling machines with a braille display
-		if [i for i in self.master_display_sizes if i>0]:
+		if self.has_vraille_masters():
 			self.transport.send(type="display", cells=cells)
+
+	def has_braille_masters(self):
+		return bool([i for i in self.master_display_sizes if i>0])
 
 	def update_index(self, index=None, **kwargs):
 		self.last_client_index = index


### PR DESCRIPTION
Here is a first attempt on implementing braille for NVDA Remote.

* Braille implementation is hook based, similar to speech and NVWave implementations. There were several reasons to drop the virtual braille display approach, particularly out of the box secure screens support.
* Both master and slave know about the braille display used at the other side of the connection
* When the slave uses braille and a master connects, the number of cells for the smallest display is used. When the slave uses no braille or another display with numCells=0, it's braille handler will be updated to use the master's numCells
* Braille input works as well. When sending keys, inputCore.manager.executeGesture is patched to send the gesture to the slave. We send gesture information as well as the path to the script which has to be executed on the slave's side. Thus, the master's gesture map is used. The slave gesture map is ignored for now.
* Braille also works on secure screens

I've been able to do this work on behalf of @babbagecom.