### PR TITLE
Do not auto-connect to configured control server on secure screens #51

### DIFF
--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -67,7 +67,9 @@ class GlobalPlugin(GlobalPlugin):
 		cs = get_config()['controlserver']
 		self.temp_location = os.path.join(shlobj.SHGetFolderPath(0, shlobj.CSIDL_COMMON_APPDATA), 'temp')
 		self.ipc_file = os.path.join(self.temp_location, 'remote.ipc')
-		if not self.check_secure_desktop() and cs['autoconnect']:
+		if globalVars.appArgs.secure:
+			self.handle_secure_desktop()
+		elif cs['autoconnect']:
 			self.perform_autoconnect()
 		self.sd_focused = False
 
@@ -392,9 +394,7 @@ class GlobalPlugin(GlobalPlugin):
 		self.sd_server.close()
 		self.sd_relay.close()
 
-	def check_secure_desktop(self):
-		if not globalVars.appArgs.secure:
-			return False
+	def handle_secure_desktop(self):
 		try:
 			with open(self.ipc_file) as fp:
 				data = json.load(fp)
@@ -405,9 +405,8 @@ class GlobalPlugin(GlobalPlugin):
 			test_socket.connect(('127.0.0.1', port))
 			test_socket.close()
 			self.connect_control(('127.0.0.1', port), channel)
-			return True
 		except:
-			return False
+			pass
 
 	__gestures = {
 		"kb:alt+NVDA+pageDown": "disconnect",


### PR DESCRIPTION
I've been able to track #51 down. There was a bug in check_secure_desktop which returned False when there was no remote.ipc file available. Here is a pr. Since I removed the checking from check_secure_desktop, I also renamed that function. Checking is now done in the __init__ function for the GlobalPlugin.