### PR TITLE
Fixed markdown to html appearance problems: changed <> to &lt;&gt;

### DIFF
--- a/addon/doc/ca/readme.md
+++ b/addon/doc/ca/readme.md
@@ -38,7 +38,7 @@ Si portcheck detecta que el teu port (per defecte 6837) no està obert, apareixe
 Obre el port i torna-ho a provar de nou.
 Nota: el procés d'obrir ports està fora del propòsit d'aquest document. Consulta la documentació que acompanya al teu router per a més informació.
 
-Introdueix una clau en el camp clau, o prem generar. L'altra persona necessitarà la teva IP externa juntament amb la clau per connectar. Si has introduït un port diferent al que es fa servir per defecte (6837) al camp port, assegura't de que l'altra persona afegeix el port alternatiu a la direcció de l'equip fent servir el format &lt;ip externa>:&lt;puerto>.
+Introdueix una clau en el camp clau, o prem generar. L'altra persona necessitarà la teva IP externa juntament amb la clau per connectar. Si has introduït un port diferent al que es fa servir per defecte (6837) al camp port, assegura't de que l'altra persona afegeix el port alternatiu a la direcció de l'equip fent servir el format &lt;ip externa&gt;:&lt;puerto&gt;.
 
 Un cop premis acceptar, estaràs connectat.
 Quan l'altra persona es connecti, podràs fer servir NVDA Remote amb normalitat.

--- a/addon/doc/ca/readme.md
+++ b/addon/doc/ca/readme.md
@@ -1,4 +1,4 @@
-#NVDA Remote Access
+﻿#NVDA Remote Access
 Versió 1.3
 
 Benvingut al complement d'accés remot de NVDA, que et permetrà connectar-te a un altre equip que executi el lector de pantalla gratuït NVDA. És igual que siguis a l'altra banda de l'habitació o a l'altra banda del món. Connectar-se és simple, i hi ha molt poques ordres per aprendre. Pots connectar-te a l'equip d'una altra persona, o permetre a una persona de confiança que es connecti al teu sistema per realitzar un manteniment rutinari, diagnosticar un problema, o ensenyar-te alguna cosa.
@@ -38,7 +38,7 @@ Si portcheck detecta que el teu port (per defecte 6837) no està obert, apareixe
 Obre el port i torna-ho a provar de nou.
 Nota: el procés d'obrir ports està fora del propòsit d'aquest document. Consulta la documentació que acompanya al teu router per a més informació.
 
-Introdueix una clau en el camp clau, o prem generar. L'altra persona necessitarà la teva IP externa juntament amb la clau per connectar. Si has introduït un port diferent al que es fa servir per defecte (6837) al camp port, assegura't de que l'altra persona afegeix el port alternatiu a la direcció de l'equip fent servir el format <ip externa>:<puerto>.
+Introdueix una clau en el camp clau, o prem generar. L'altra persona necessitarà la teva IP externa juntament amb la clau per connectar. Si has introduït un port diferent al que es fa servir per defecte (6837) al camp port, assegura't de que l'altra persona afegeix el port alternatiu a la direcció de l'equip fent servir el format &lt;ip externa>:&lt;puerto>.
 
 Un cop premis acceptar, estaràs connectat.
 Quan l'altra persona es connecti, podràs fer servir NVDA Remote amb normalitat.

--- a/addon/doc/en/readme.md
+++ b/addon/doc/en/readme.md
@@ -13,7 +13,7 @@ The installation of both NVDA and the Remote Access addon are standard. If you n
 1. Open the NVDA menu, Tools, Remote, Connect.
 2. Choose client in the first radio button.
 3. Select Allow this machine to be controlled in the second set of radio buttons.
-4. In the host field, enter the host of the server you are connecting to, for example nvdaremote.com. When the particular server uses an alternative port, you can enter the host in the form <host>:<port>, for example nvdaremote.com:1234.
+4. In the host field, enter the host of the server you are connecting to, for example nvdaremote.com. When the particular server uses an alternative port, you can enter the host in the form &lt;host&gt;:&lt;port&gt;, for example nvdaremote.com:1234.
 5. Enter a key into the key field, or press the generate key button.
 The key is what others will use to control your computer.
 The machine being controlled and all its clients need to use the same key.
@@ -23,7 +23,7 @@ The machine being controlled and all its clients need to use the same key.
 1. Open the NVDA menu, Tools, Remote, Connect.
 2. Choose client in the first radio button.
 3. Select Control another machine in the second set of radio buttons.
-4. In the host field, enter the host of the server you are connecting to, for example nvdaremote.com. When the particular server uses an alternative port, you can enter the host in the form <host>:<port>, for example nvdaremote.com:1234.
+4. In the host field, enter the host of the server you are connecting to, for example nvdaremote.com. When the particular server uses an alternative port, you can enter the host in the form &lt;host&gt;:&lt;port&gt;, for example nvdaremote.com:1234.
 5. Enter a key into the key field, or press the generate key button.
 The machine being controlled and all its clients need to use the same key.
 6. Press ok. Once done, you will hear a tone and connected.
@@ -39,7 +39,7 @@ If portcheck detects that your port (6837 by default) is not reachable, a warnin
 Forward your port and try again.
 Note: The process for forwarding ports is outside of the scope of this document. Please consult the information provided with your router for further instruction.
 
-Enter a key into the key field, or press generate. The other person will need your external IP along with the key to connect. If you entered a port other than the default (6837) in the port field, make sure that the other person appends the alternative port to the host address in the form <external ip>:<port>.
+Enter a key into the key field, or press generate. The other person will need your external IP along with the key to connect. If you entered a port other than the default (6837) in the port field, make sure that the other person appends the alternative port to the host address in the form &lt;external ip&gt;:&lt;port&gt;.
 
 Once ok is pressed, you will be connected.
 When the other person connects, you can use NVDA Remote normally.

--- a/addon/doc/es/readme.md
+++ b/addon/doc/es/readme.md
@@ -1,4 +1,4 @@
-#NVDA Remote Access
+﻿#NVDA Remote Access
 Versión 1.3
 
 Bienvenido al complemento de acceso remoto de NVDA, que te permitirá conectarte a otro equipo que ejecute el lector de pantalla gratuito NVDA. Da igual que estés al otro lado de la habitación o al otro lado del mundo. Conectarse es simple, y hay muy pocas órdenes que aprenderse. Puedes conectarte al equipo de otra persona, o permitir a una persona de confianza que se conecte a tu sistema para realizar un mantenimiento rutinario, diagnosticar un problema, o enseñarte algo.
@@ -13,7 +13,7 @@ La instalación de NVDA y del complemento no varía con respecto a otras. Si nec
 1. Abre el menú de NVDA, herramientas, remoto, conectar.
 2. Elige cliente en el primer grupo de botones de opción.
 3. Elige permitir que controlen este equipo en el segundo grupo de botones de opción.
-4. En el campo equipo o servidor, introduce el servidor al que te vas a conectar, por ejemplo nvdaremote.com. Si el servidor usa un puerto distinto al que este complemento utiliza por defecto, puedes introducir su dirección en formato <equipo>:<puerto>, por ejemplo nvdaremote.com:1234.
+4. En el campo equipo o servidor, introduce el servidor al que te vas a conectar, por ejemplo nvdaremote.com. Si el servidor usa un puerto distinto al que este complemento utiliza por defecto, puedes introducir su dirección en formato &lt;equipo&gt;:&lt;puerto&gt;, por ejemplo nvdaremote.com:1234.
 5. Introduce una clave en el campo clave, o pulsa el botón generar clave.
 La clave es lo que otros usarán para controlar tu equipo.
 La máquina controlada y todos sus clientes deben usar la misma clave.
@@ -23,7 +23,7 @@ La máquina controlada y todos sus clientes deben usar la misma clave.
 1. Abre el menú de NVDA, herramientas, remoto, conectar.
 2. Elige cliente en el primer grupo de botones de opción.
 3. Selecciona controlar otro equipo en el segundo grupo de botones de opción.
-4. En el campo equipo o servidor, introduce el servidor al que te vas a conectar, por ejemplo nvdaremote.com. Si el servidor usa un puerto distinto al que este complemento utiliza por defecto, puedes introducir su dirección en formato <equipo>:<puerto>, por ejemplo nvdaremote.com:1234.
+4. En el campo equipo o servidor, introduce el servidor al que te vas a conectar, por ejemplo nvdaremote.com. Si el servidor usa un puerto distinto al que este complemento utiliza por defecto, puedes introducir su dirección en formato &lt;equipo&gt;:&lt;puerto&gt;, por ejemplo nvdaremote.com:1234.
 5. Introduce una clave en el campo clave, o pulsa el botón generar clave.
 La máquina controlada y todos sus clientes deben usar la misma clave.
 6. Pulsa aceptar. Hecho esto, escucharás un pitido y conectado.
@@ -38,7 +38,7 @@ Si portcheck detecta que tu puerto (por defecto 6837) no está abierto, aparecer
 Abre el puerto e inténtalo de nuevo.
 Nota: el proceso de abrir puertos está fuera del propósito de este documento. Consulta la documentación que acompaña a tu router para más información.
 
-Introduce una clave en el campo clave, o pulsa generar. La otra persona necesitará tu IP externa junto con la clave para conectar. Si has introducido un puerto distinto al que se usa por defecto (6837) en el campo puerto, asegúrate de que la otra persona añade el puerto alternativo a la dirección del equipo usando el formato <ip externa>:<puerto>.
+Introduce una clave en el campo clave, o pulsa generar. La otra persona necesitará tu IP externa junto con la clave para conectar. Si has introducido un puerto distinto al que se usa por defecto (6837) en el campo puerto, asegúrate de que la otra persona añade el puerto alternativo a la dirección del equipo usando el formato &lt;ip externa&gt;:&lt;puerto&gt;.
 
 Una vez pulses aceptar, estarás conectado.
 Cuando la otra persona se conecte, podrás usar NVDA Remote con normalidad.

--- a/addon/doc/es_CO/readme.md
+++ b/addon/doc/es_CO/readme.md
@@ -24,7 +24,7 @@ El equipo que está siendo controlado y todos sus clientes necesitan utilizar la
 1. Abrir el menú de NVDA, herramientas, remoto, conectar. 
 2. Seleccionar cliente en el primer grupo de botones radiales. 
 3. Seleccionar "controlar otra máquina" en el segundo conjunto de botones radiales.
-4. en el campo host, ingresa el host del servidor al que te estás conectando, por ejemplo, nvdaremote.com. Cuando el servidor particular utilice un puerto alternativo, puedes ingresar el host en el formato &lt;host>:&lt;puerto>, por ejemplo nvdaremote.com:1234.
+4. en el campo host, ingresa el host del servidor al que te estás conectando, por ejemplo, nvdaremote.com. Cuando el servidor particular utilice un puerto alternativo, puedes ingresar el host en el formato &lt;host&gt;:&lt;puerto&gt;, por ejemplo nvdaremote.com:1234.
 5. Ingresa una clave en el campo clave, o presiona el botón generar clave.
 La clave es lo que otros utilizarán para controlar tu equipo.
 El equipo que está siendo controlado y todos sus clientes necesitan utilizar la misma clave.
@@ -41,7 +41,7 @@ Si portChec detecta que tu puerto (6837 por defecto) no se puede alcanzar, apare
 Abre el puerto y vuelve a intentarlo.
 Nota: el proceso para abrir puertos va más allá del alcance  de este documento. Por favor, consulta la información suministrada con tu router para más instrucciones.
 
-Ingresa una clave en el campo clave, o presiona generar. La otra persona necesitará tanto tu IP externa como la clave para conectarse. Si ingresaste un puerto diferente del predeterminado (6837) en el campo "puerto", aseguúrate de que la otra persona agregue el puerto alternativo a la dirección del host en el formato &lt;ip externa>:&lt;puerto>.
+Ingresa una clave en el campo clave, o presiona generar. La otra persona necesitará tanto tu IP externa como la clave para conectarse. Si ingresaste un puerto diferente del predeterminado (6837) en el campo "puerto", aseguúrate de que la otra persona agregue el puerto alternativo a la dirección del host en el formato &lt;ip externa&gt;:&lt;puerto&gt;.
 
 Una vez que se presione aceptar, estarás conectado.
 Cuando la otra persona se conecte, puedes usar NVDA Remote normalmente.

--- a/addon/doc/es_CO/readme.md
+++ b/addon/doc/es_CO/readme.md
@@ -1,4 +1,4 @@
-#NVDA Remote Access
+﻿#NVDA Remote Access
 Versión 1.3
 
 Bienvenido al complemento NVDA Remote Access, el cual te permitirá conectarte a otro equipo que ejecute el lector de pantallas gratuito NVDA. No hace ninguna diferencia si te encuentras al otro lado del cuarto, o al otro lado del mundo. Conectarse es simple, y hay muy pocos comandos que recordar . Puedes conectarte al equipo de otra persona, o permitir que una persona de confianza se conecte a tu sistema para realizar mantenimientos de rutina, diagnosticar un problema o suministrar entrenamiento.
@@ -24,7 +24,7 @@ El equipo que está siendo controlado y todos sus clientes necesitan utilizar la
 1. Abrir el menú de NVDA, herramientas, remoto, conectar. 
 2. Seleccionar cliente en el primer grupo de botones radiales. 
 3. Seleccionar "controlar otra máquina" en el segundo conjunto de botones radiales.
-4. en el campo host, ingresa el host del servidor al que te estás conectando, por ejemplo, nvdaremote.com. Cuando el servidor particular utilice un puerto alternativo, puedes ingresar el host en el formato <host>:<puerto>, por ejemplo nvdaremote.com:1234.
+4. en el campo host, ingresa el host del servidor al que te estás conectando, por ejemplo, nvdaremote.com. Cuando el servidor particular utilice un puerto alternativo, puedes ingresar el host en el formato &lt;host>:&lt;puerto>, por ejemplo nvdaremote.com:1234.
 5. Ingresa una clave en el campo clave, o presiona el botón generar clave.
 La clave es lo que otros utilizarán para controlar tu equipo.
 El equipo que está siendo controlado y todos sus clientes necesitan utilizar la misma clave.
@@ -41,7 +41,7 @@ Si portChec detecta que tu puerto (6837 por defecto) no se puede alcanzar, apare
 Abre el puerto y vuelve a intentarlo.
 Nota: el proceso para abrir puertos va más allá del alcance  de este documento. Por favor, consulta la información suministrada con tu router para más instrucciones.
 
-Ingresa una clave en el campo clave, o presiona generar. La otra persona necesitará tanto tu IP externa como la clave para conectarse. Si ingresaste un puerto diferente del predeterminado (6837) en el campo "puerto", aseguúrate de que la otra persona agregue el puerto alternativo a la dirección del host en el formato <ip externa>:<puerto>.
+Ingresa una clave en el campo clave, o presiona generar. La otra persona necesitará tanto tu IP externa como la clave para conectarse. Si ingresaste un puerto diferente del predeterminado (6837) en el campo "puerto", aseguúrate de que la otra persona agregue el puerto alternativo a la dirección del host en el formato &lt;ip externa>:&lt;puerto>.
 
 Una vez que se presione aceptar, estarás conectado.
 Cuando la otra persona se conecte, puedes usar NVDA Remote normalmente.

--- a/addon/doc/gl/readme.md
+++ b/addon/doc/gl/readme.md
@@ -13,7 +13,7 @@ A instalación de NVDA e do complemento non varía con respecto a outras. Se nec
 1. Abre o menú de NVDA, ferramentas, remoto, conectar.
 2. Elixe cliente no primeiro grupo de botóns de opción.
 3. Elixe permitir que controlen este equipo no segundo grupo de botóns de opción.
-4. No campo equipo ou servidor, introduce o servidor ao que te vas a conectar, por exemplo nvdaremote.com. Cando o servidor remoto utiliza un porto diferente (ao 6837), pode introducir o nome na forma <servidor>:<porto>, por exemplo nvdaremote.com:1234.
+4. No campo equipo ou servidor, introduce o servidor ao que te vas a conectar, por exemplo nvdaremote.com. Cando o servidor remoto utiliza un porto diferente (ao 6837), pode introducir o nome na forma &lt;servidor&gt;:&lt;porto&gt;, por exemplo nvdaremote.com:1234.
 5. Introduce unha clave no campo clave, ou preme o botón xerar clave.
 A clave é o que outros utilizarán para controlar o teu equipo.
 A máquina controlada e todos os seus clientes deben usar a mesma clave.
@@ -23,7 +23,7 @@ A máquina controlada e todos os seus clientes deben usar a mesma clave.
 1. Abre o menú de NVDA, ferramentas, remoto, conectar.
 2. Elixe cliente no primeiro grupo de botóns de opción.
 3. Elixe controlar outro equipo no segundo grupo de botóns de opción.
-4. No campo equipo ou servidor, introduce o servidor ao que te vas a conectar, por exemplo nvdaremote.com. Cando o servidor remoto utiliza un porto diferente (ao 6837), pode introducir o nome na forma <servidor>:<porto>, por exemplo nvdaremote.com:1234.
+4. No campo equipo ou servidor, introduce o servidor ao que te vas a conectar, por exemplo nvdaremote.com. Cando o servidor remoto utiliza un porto diferente (ao 6837), pode introducir o nome na forma &lt;servidor&gt;:&lt;porto&gt;, por exemplo nvdaremote.com:1234.
 5. Introduce unha clave no campo clave, ou preme o botón xerar clave.
 A clave é o que outros utilizarán para controlar o teu equipo.
 A máquina controlada e todos os seus clientes deben usar a mesma clave.
@@ -39,7 +39,7 @@ Se portcheck detecta que o porto (por defecto 6837) non se pode alcanzar dende I
 Reenvía(abre) o porto e inténtao de novo.
 Nota: o proceso de reenviar portos está fóra do propósito deste documento. Consulta a documentación que acompaña ao teu router para máis información.
 
-Introduce unha clave no campo clave, ou preme xerar. A outra persoa necesitará o teu IP externo xunto coa clave para conectar. Se se introduciu un porto diferente ao predeterminado (6837) no campo "porto", asegúrate de que a outra persoa engade o porto ó enderezo do equipo na forma <IP externo>:<porto>.
+Introduce unha clave no campo clave, ou preme xerar. A outra persoa necesitará o teu IP externo xunto coa clave para conectar. Se se introduciu un porto diferente ao predeterminado (6837) no campo "porto", asegúrate de que a outra persoa engade o porto ó enderezo do equipo na forma &lt;IP externo&gt;:&lt;porto&gt;.
 
 Unha vez premas aceptar, estarás conectado.
 Cando a outra persoa se conecte, poderás usar NVDA Remote con normalidade.
@@ -110,4 +110,4 @@ Gustaríanos dar o noso recoñecemento aos seguintes contribuíntes que, entre o
 * Tyler W Kavanaugh
 * Casey Mathews
 
-Traducido ao galego por Iván Novegil <info@inovegil.site40.net>
+Traducido ao galego por Iván Novegil &lt;info@inovegil.site40.net&gt;

--- a/addon/doc/nl/readme.md
+++ b/addon/doc/nl/readme.md
@@ -12,7 +12,7 @@ Het is nodig dat u NVDA geïnstalleerd hebt op beide computers, waarbij u tevens
 1. Open het NVDA-menu, Extra's, Externe toegang, Verbinden.
 2. Kies voor client bij de eerste reeks met keuzerondjes.
 3. In de tweede reeks keuzerondjes kiest u voor de optie Laat deze machine beheerd worden.
-4. In het veld Adres vult u het adres van de server in waarnaar u gaat verbinden, bijvoorbeeld nvdaremote.com. Wanneer de betreffende server een alternatieve poort gebruikt, voert u het adres in in de vorm &lt;host>:&lt;port>, bijvoorbeeld nvdaremote.com:1234.
+4. In het veld Adres vult u het adres van de server in waarnaar u gaat verbinden, bijvoorbeeld nvdaremote.com. Wanneer de betreffende server een alternatieve poort gebruikt, voert u het adres in in de vorm &lt;host&gt;:&lt;port&gt;, bijvoorbeeld nvdaremote.com:1234.
 5. Vul in het veld sleutel een toegangssleutel in, of kies voor de knop Sleutel genereren.
 Deze toegangssleutel wordt door anderen gebruikt om uw computer te beheren.
 De machine die beheert wordt en de bijbehorende clients dienen gebruik te maken van de zelfde sleutel.
@@ -22,7 +22,7 @@ De machine die beheert wordt en de bijbehorende clients dienen gebruik te maken 
 1. Open het NVDA-menu, Extra's, Externe toegang, Verbinden.
 2. Kies voor client bij de eerste reeks met keuzerondjes.
 3. In de tweede reeks keuzerondjes kiest u voor de optie Beheer een andere machine.
-4. In het veld Adres vult u het adres van de server in waarnaar u gaat verbinden, bijvoorbeeld nvdaremote.com. Wanneer de betreffende server een alternatieve poort gebruikt, voert u het adres in in de vorm &lt;host>:&lt;port>, bijvoorbeeld nvdaremote.com:1234.
+4. In het veld Adres vult u het adres van de server in waarnaar u gaat verbinden, bijvoorbeeld nvdaremote.com. Wanneer de betreffende server een alternatieve poort gebruikt, voert u het adres in in de vorm &lt;host&gt;:&lt;port&gt;, bijvoorbeeld nvdaremote.com:1234.
 5. Vul in het veld sleutel een toegangssleutel in, of kies voor de knop Sleutel genereren.
 De machine die beheert wordt en de bijbehorende clients dienen gebruik te maken van de zelfde sleutel.
 6. Druk op Ok. Wanneer de verbinding tot stand gebracht is hoort u een toon, evenals de melding Verbonden.
@@ -37,7 +37,7 @@ Wanneer portcheck detecteert dat uw poort (standaard 6837) niet bereikbaar is, z
 Open in dat geval uw poort in uw router of firewall en probeer het nogmaals.
 Let op: Het proces van het openen van poorten valt buiten het bestek van dit document. Raadpleeg de informatie bij uw router voor verdere instructies.
 
-Voer in het veld Sleutel een toegangssleutel in, of laat een sleutel genereren. De andere persoon heeft zowel uw externe IP als de toegangssleutel nodig om verbinding te maken. Wanneer u in het poort invoerveld een poort hebt ingevoerd die afwijkt van de standaard (6837), dient u er zeker van te zijn dat de andere persoon de alternatieve poort toevoegt aan het serveradres in de vorm &lt;extern ip>:&lt;poort>.
+Voer in het veld Sleutel een toegangssleutel in, of laat een sleutel genereren. De andere persoon heeft zowel uw externe IP als de toegangssleutel nodig om verbinding te maken. Wanneer u in het poort invoerveld een poort hebt ingevoerd die afwijkt van de standaard (6837), dient u er zeker van te zijn dat de andere persoon de alternatieve poort toevoegt aan het serveradres in de vorm &lt;extern ip&gt;:&lt;poort&gt;.
 
 Zodra er voor Ok gekozen wordt, zal de verbinding met uw eigen server tot stand worden gebracht. Zodra de andere persoon verbinding maakt, kunt u NVDA Externe Toegang op de normale manier gebruiken.
 

--- a/addon/doc/nl/readme.md
+++ b/addon/doc/nl/readme.md
@@ -1,4 +1,4 @@
-#NVDA Externe Toegang
+﻿#NVDA Externe Toegang
 Versie 1.2
 
 Welkom bij de NVDA Externe Toegang add-on, die u in staat stelt om verbinding te maken met een andere computer die gebruikt maakt van de gratis NVDA schermlezer. Het maakt hierbij geen verschil of u zich aan de andere kant van één en de zelfde ruimte, of aan de andere kant van de wereld bevindt. Verbinding maken is eenvoudig en er zijn slechts een aantal commando's om te onthouden. U kunt verbinding maken met de computer van een andere persoon, of een vertrouwd persoon toestaan om verbinding te maken met uw systeem voor het uitvoeren van routine-onderhoud, het vaststellen van een probleem of het geven van training.
@@ -12,7 +12,7 @@ Het is nodig dat u NVDA geïnstalleerd hebt op beide computers, waarbij u tevens
 1. Open het NVDA-menu, Extra's, Externe toegang, Verbinden.
 2. Kies voor client bij de eerste reeks met keuzerondjes.
 3. In de tweede reeks keuzerondjes kiest u voor de optie Laat deze machine beheerd worden.
-4. In het veld Adres vult u het adres van de server in waarnaar u gaat verbinden, bijvoorbeeld nvdaremote.com. Wanneer de betreffende server een alternatieve poort gebruikt, voert u het adres in in de vorm <host>:<port>, bijvoorbeeld nvdaremote.com:1234.
+4. In het veld Adres vult u het adres van de server in waarnaar u gaat verbinden, bijvoorbeeld nvdaremote.com. Wanneer de betreffende server een alternatieve poort gebruikt, voert u het adres in in de vorm &lt;host>:&lt;port>, bijvoorbeeld nvdaremote.com:1234.
 5. Vul in het veld sleutel een toegangssleutel in, of kies voor de knop Sleutel genereren.
 Deze toegangssleutel wordt door anderen gebruikt om uw computer te beheren.
 De machine die beheert wordt en de bijbehorende clients dienen gebruik te maken van de zelfde sleutel.
@@ -22,7 +22,7 @@ De machine die beheert wordt en de bijbehorende clients dienen gebruik te maken 
 1. Open het NVDA-menu, Extra's, Externe toegang, Verbinden.
 2. Kies voor client bij de eerste reeks met keuzerondjes.
 3. In de tweede reeks keuzerondjes kiest u voor de optie Beheer een andere machine.
-4. In het veld Adres vult u het adres van de server in waarnaar u gaat verbinden, bijvoorbeeld nvdaremote.com. Wanneer de betreffende server een alternatieve poort gebruikt, voert u het adres in in de vorm <host>:<port>, bijvoorbeeld nvdaremote.com:1234.
+4. In het veld Adres vult u het adres van de server in waarnaar u gaat verbinden, bijvoorbeeld nvdaremote.com. Wanneer de betreffende server een alternatieve poort gebruikt, voert u het adres in in de vorm &lt;host>:&lt;port>, bijvoorbeeld nvdaremote.com:1234.
 5. Vul in het veld sleutel een toegangssleutel in, of kies voor de knop Sleutel genereren.
 De machine die beheert wordt en de bijbehorende clients dienen gebruik te maken van de zelfde sleutel.
 6. Druk op Ok. Wanneer de verbinding tot stand gebracht is hoort u een toon, evenals de melding Verbonden.
@@ -37,7 +37,7 @@ Wanneer portcheck detecteert dat uw poort (standaard 6837) niet bereikbaar is, z
 Open in dat geval uw poort in uw router of firewall en probeer het nogmaals.
 Let op: Het proces van het openen van poorten valt buiten het bestek van dit document. Raadpleeg de informatie bij uw router voor verdere instructies.
 
-Voer in het veld Sleutel een toegangssleutel in, of laat een sleutel genereren. De andere persoon heeft zowel uw externe IP als de toegangssleutel nodig om verbinding te maken. Wanneer u in het poort invoerveld een poort hebt ingevoerd die afwijkt van de standaard (6837), dient u er zeker van te zijn dat de andere persoon de alternatieve poort toevoegt aan het serveradres in de vorm <extern ip>:<poort>.
+Voer in het veld Sleutel een toegangssleutel in, of laat een sleutel genereren. De andere persoon heeft zowel uw externe IP als de toegangssleutel nodig om verbinding te maken. Wanneer u in het poort invoerveld een poort hebt ingevoerd die afwijkt van de standaard (6837), dient u er zeker van te zijn dat de andere persoon de alternatieve poort toevoegt aan het serveradres in de vorm &lt;extern ip>:&lt;poort>.
 
 Zodra er voor Ok gekozen wordt, zal de verbinding met uw eigen server tot stand worden gebracht. Zodra de andere persoon verbinding maakt, kunt u NVDA Externe Toegang op de normale manier gebruiken.
 


### PR DESCRIPTION
Changed on all updated documentations < by &lt; and > by &gt; to make the navigators showing correctly the text surrounded by these symbols after converting markdown into HTML (now it only displays ":" in place of "<host>:<port>" or its respective translation).
Documentation for this change: https://daringfireball.net/projects/markdown/syntax > AUTOMATIC ESCAPING FOR SPECIAL CHARACTERS
Any problem please comment.