### PR TITLE
Large, needed  Code Cleanup/method rename

### DIFF
--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -162,8 +162,7 @@ class GlobalPlugin(GlobalPlugin):
 		try:
 			connector.send(type='set_clipboard_text', text=api.getClipData())
 		except TypeError:
-			# JL: It might be helpful to provide a log.debug output for this.
-			pass
+			log.exception("Unable to push clipboard")
 
 	def on_options_item(self, evt):
 		evt.Skip()

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -302,7 +302,7 @@ class GlobalPlugin(GlobalPlugin):
 	def connected_to_relay(self):
 		log.info("Control connector connected")
 		beep_sequence.beep_sequence((720, 100), 50, (720, 100), 50, (720, 100))
-		# Transaltors: Presented in direct (client to server) remote connection when the controlled computer is ready.
+		# Translators: Presented in direct (client to server) remote connection when the controlled computer is ready.
 		speech.speakMessage(_("Connected to control server"))
 		self.push_clipboard_item.Enable(True)
 		write_connection_to_config(self.slave_transport.address)

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -188,7 +188,7 @@ class GlobalPlugin(GlobalPlugin):
 		if self.master_transport is not None:
 			self.disconnect_from_slave()
 		if self.slave_transport is not None:
-			self.disconnect_control()
+			self.disconnect_as_slave()
 		if self.server is not None:
 			self.server.close()
 			self.server = None
@@ -215,7 +215,7 @@ class GlobalPlugin(GlobalPlugin):
 			self.removeGestureBinding(REMOTE_KEY)
 		self.key_modified = False
 
-	def disconnect_control(self):
+	def disconnect_as_slave(self):
 		self.slave_transport.close()
 		self.slave_transport = None
 

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -78,7 +78,7 @@ class GlobalPlugin(GlobalPlugin):
 			self.start_control_server(port, channel)
 		else:
 			address = address_to_hostport(cs['host'])
-		self.connect_control(address, channel)
+		self.connect_as_slave(address, channel)
 
 	def create_menu(self):
 		self.menu = wx.Menu()
@@ -251,14 +251,14 @@ class GlobalPlugin(GlobalPlugin):
 				if dlg.connection_type.GetSelection() == 0:
 					self.connect_slave((server_addr, port), channel)
 				else:
-					self.connect_control((server_addr, port), channel)
+					self.connect_as_slave((server_addr, port), channel)
 			else: #We want a server
 				channel = dlg.panel.key.GetValue()
 				self.start_control_server(int(dlg.panel.port.GetValue()), channel)
 				if dlg.connection_type.GetSelection() == 0:
 					self.connect_slave(('127.0.0.1', int(dlg.panel.port.GetValue())), channel)
 				else:
-					self.connect_control(('127.0.0.1', int(dlg.panel.port.GetValue())), channel)
+					self.connect_as_slave(('127.0.0.1', int(dlg.panel.port.GetValue())), channel)
 		gui.runScriptModalDialog(dlg, callback=handle_dlg_complete)
 
 	def on_connected_to_slave(self):
@@ -289,7 +289,7 @@ class GlobalPlugin(GlobalPlugin):
 		self.master_transport = transport
 		self.master_transport.reconnector_thread.start()
 
-	def connect_control(self, address, key=None):
+	def connect_as_slave(self, address, key=None):
 		transport = RelayTransport(serializer=serializer.JSONSerializer(), address=address, channel=key)
 		self.slave_session = SlaveSession(transport=transport, local_machine=self.local_machine)
 		self.slave_transport = transport
@@ -391,7 +391,7 @@ class GlobalPlugin(GlobalPlugin):
 			test_socket=ssl.wrap_socket(test_socket)
 			test_socket.connect(('127.0.0.1', port))
 			test_socket.close()
-			self.connect_control(('127.0.0.1', port), channel)
+			self.connect_as_slave(('127.0.0.1', port), channel)
 			return True
 		except:
 			return False

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -110,7 +110,7 @@ class GlobalPlugin(GlobalPlugin):
 		self.remote_item=tools_menu.AppendSubMenu(self.menu, _("R&emote"), _("NVDA Remote Access"))
 
 	def terminate(self):
-		self.do_disconnect_from_slave()
+		self.disconnect()
 		self.local_machine = None
 		self.menu.RemoveItem(self.connect_item)
 		self.connect_item.Destroy()
@@ -146,7 +146,7 @@ class GlobalPlugin(GlobalPlugin):
 
 	def on_disconnect_item(self, evt):
 		evt.Skip()
-		self.do_disconnect_from_slave()
+		self.disconnect()
 
 	def on_mute_item(self, evt):
 		evt.Skip()
@@ -180,7 +180,7 @@ class GlobalPlugin(GlobalPlugin):
 	def on_send_ctrl_alt_del(self, evt):
 		self.master_transport.send('send_SAS')
 
-	def do_disconnect_from_slave(self):
+	def disconnect(self):
 		if self.master_transport is None and self.slave_transport is None:
 			return
 		if self.master_transport is not None:
@@ -229,7 +229,7 @@ class GlobalPlugin(GlobalPlugin):
 		if self.master_transport is None and self.slave_transport is None:
 			ui.message(_("Not connected."))
 			return
-		self.do_disconnect_from_slave()
+		self.disconnect()
 	script_disconnect.__doc__ = _("""Disconnect a remote session""")
 
 	def do_connect(self, evt):

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -110,7 +110,7 @@ class GlobalPlugin(GlobalPlugin):
 		self.remote_item=tools_menu.AppendSubMenu(self.menu, _("R&emote"), _("NVDA Remote Access"))
 
 	def terminate(self):
-		self.do_disconnect_from_slave(True)
+		self.do_disconnect_from_slave()
 		self.local_machine = None
 		self.menu.RemoveItem(self.connect_item)
 		self.connect_item.Destroy()
@@ -180,10 +180,8 @@ class GlobalPlugin(GlobalPlugin):
 	def on_send_ctrl_alt_del(self, evt):
 		self.master_transport.send('send_SAS')
 
-	def do_disconnect_from_slave(self, quiet=False):
+	def do_disconnect_from_slave(self):
 		if self.master_transport is None and self.slave_transport is None:
-			if not quiet:
-				ui.message(_("Not connected."))
 			return
 		if self.master_transport is not None:
 			self.disconnect_as_master()
@@ -228,6 +226,9 @@ class GlobalPlugin(GlobalPlugin):
 			message=_("Unable to connect to the remote computer"), style=wx.OK | wx.ICON_WARNING)
 
 	def script_disconnect(self, gesture):
+		if self.master_transport is None and self.slave_transport is None:
+			ui.message(_("Not connected."))
+			return
 		self.do_disconnect_from_slave()
 	script_disconnect.__doc__ = _("""Disconnect a remote session""")
 

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -261,7 +261,7 @@ class GlobalPlugin(GlobalPlugin):
 					self.connect_as_slave(('127.0.0.1', int(dlg.panel.port.GetValue())), channel)
 		gui.runScriptModalDialog(dlg, callback=handle_dlg_complete)
 
-	def on_connected_to_slave(self):
+	def on_connected_as_master(self):
 		write_connection_to_config(self.master_transport.address)
 		self.disconnect_item.Enable(True)
 		self.connect_item.Enable(False)
@@ -283,7 +283,7 @@ class GlobalPlugin(GlobalPlugin):
 	def connect_as_master(self, address, channel):
 		transport = RelayTransport(address=address, serializer=serializer.JSONSerializer(), channel=channel)
 		self.master_session = MasterSession(transport=transport, local_machine=self.local_machine)
-		transport.callback_manager.register_callback('transport_connected', self.on_connected_to_slave)
+		transport.callback_manager.register_callback('transport_connected', self.on_connected_as_master)
 		transport.callback_manager.register_callback('transport_connection_failed', self.on_slave_connection_failed)
 		transport.callback_manager.register_callback('transport_disconnected', self.on_disconnected_from_slave)
 		self.master_transport = transport

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -186,7 +186,7 @@ class GlobalPlugin(GlobalPlugin):
 				ui.message(_("Not connected."))
 			return
 		if self.master_transport is not None:
-			self.disconnect_from_slave()
+			self.disconnect_as_master()
 		if self.slave_transport is not None:
 			self.disconnect_as_slave()
 		if self.server is not None:
@@ -197,7 +197,7 @@ class GlobalPlugin(GlobalPlugin):
 		self.connect_item.Enable(True)
 		self.push_clipboard_item.Enable(False)
 
-	def disconnect_from_slave(self):
+	def disconnect_as_master(self):
 		self.master_transport.close()
 		self.master_transport = None
 		self.connect_item.Enable(True)
@@ -221,7 +221,7 @@ class GlobalPlugin(GlobalPlugin):
 
 	def on_slave_connection_failed(self):
 		if self.master_transport.successful_connects == 0:
-			self.disconnect_from_slave()
+			self.disconnect_as_master()
 			# Translators: Title of the connection error dialog.
 			gui.messageBox(parent=gui.mainFrame, caption=_("Error Connecting"),
 			# Translators: Message shown when cannot connect to the remote computer.

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -296,12 +296,12 @@ class GlobalPlugin(GlobalPlugin):
 		transport = RelayTransport(serializer=serializer.JSONSerializer(), address=address, channel=key)
 		self.slave_session = SlaveSession(transport=transport, local_machine=self.local_machine)
 		self.slave_transport = transport
-		self.slave_transport.callback_manager.register_callback('transport_connected', self.connected_to_relay)
+		self.slave_transport.callback_manager.register_callback('transport_connected', self.on_connected_as_slave)
 		self.slave_transport.reconnector_thread.start()
 		self.disconnect_item.Enable(True)
 		self.connect_item.Enable(False)
 
-	def connected_to_relay(self):
+	def on_connected_as_slave(self):
 		log.info("Control connector connected")
 		beep_sequence.beep_sequence((720, 100), 50, (720, 100), 50, (720, 100))
 		# Translators: Presented in direct (client to server) remote connection when the controlled computer is ready.

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -249,14 +249,14 @@ class GlobalPlugin(GlobalPlugin):
 				server_addr, port = address_to_hostport(server_addr)
 				channel = dlg.panel.key.GetValue()
 				if dlg.connection_type.GetSelection() == 0:
-					self.connect_slave((server_addr, port), channel)
+					self.connect_as_master((server_addr, port), channel)
 				else:
 					self.connect_as_slave((server_addr, port), channel)
 			else: #We want a server
 				channel = dlg.panel.key.GetValue()
 				self.start_control_server(int(dlg.panel.port.GetValue()), channel)
 				if dlg.connection_type.GetSelection() == 0:
-					self.connect_slave(('127.0.0.1', int(dlg.panel.port.GetValue())), channel)
+					self.connect_as_master(('127.0.0.1', int(dlg.panel.port.GetValue())), channel)
 				else:
 					self.connect_as_slave(('127.0.0.1', int(dlg.panel.port.GetValue())), channel)
 		gui.runScriptModalDialog(dlg, callback=handle_dlg_complete)
@@ -280,7 +280,7 @@ class GlobalPlugin(GlobalPlugin):
 		# Translators: Presented when connection to a remote computer was interupted.
 		ui.message(_("Connection interrupted"))
 
-	def connect_slave(self, address, channel):
+	def connect_as_master(self, address, channel):
 		transport = RelayTransport(address=address, serializer=serializer.JSONSerializer(), channel=channel)
 		self.master_session = MasterSession(transport=transport, local_machine=self.local_machine)
 		transport.callback_manager.register_callback('transport_connected', self.on_connected_to_slave)

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -1,4 +1,3 @@
-SERVER_ADDR = ('127.0.0.1', 5000)
 CONFIG_FILE_NAME = 'remote.ini'
 REMOTE_KEY = "kb:f11"
 from cStringIO import StringIO
@@ -295,7 +294,7 @@ class GlobalPlugin(GlobalPlugin):
 		self.connector_thread = ConnectorThread(connector=transport)
 		self.connector_thread.start()
 
-	def connect_control(self, address=SERVER_ADDR, key=None):
+	def connect_control(self, address, key=None):
 		if self.control_connector_thread is not None:
 			self.control_connector_thread.running = False
 			if self.control_connector is not None:

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -21,7 +21,7 @@ import wx
 import gui
 import beep_sequence
 import speech
-from transport import RelayTransport, ConnectorThread
+from transport import RelayTransport
 import local_machine
 import serializer
 from session import MasterSession, SlaveSession

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -216,7 +216,7 @@ class GlobalPlugin(GlobalPlugin):
 		self.slave_transport.close()
 		self.slave_transport = None
 
-	def on_slave_connection_failed(self):
+	def on_connected_as_master_failed(self):
 		if self.master_transport.successful_connects == 0:
 			self.disconnect_as_master()
 			# Translators: Title of the connection error dialog.
@@ -284,7 +284,7 @@ class GlobalPlugin(GlobalPlugin):
 		transport = RelayTransport(address=address, serializer=serializer.JSONSerializer(), channel=channel)
 		self.master_session = MasterSession(transport=transport, local_machine=self.local_machine)
 		transport.callback_manager.register_callback('transport_connected', self.on_connected_as_master)
-		transport.callback_manager.register_callback('transport_connection_failed', self.on_slave_connection_failed)
+		transport.callback_manager.register_callback('transport_connection_failed', self.on_connected_as_master_failed)
 		transport.callback_manager.register_callback('transport_disconnected', self.on_disconnected_from_slave)
 		self.master_transport = transport
 		self.master_transport.reconnector_thread.start()

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -197,6 +197,8 @@ class GlobalPlugin(GlobalPlugin):
 	def disconnect_as_master(self):
 		self.master_transport.close()
 		self.master_transport = None
+
+	def disconnecting_as_master(self):
 		self.connect_item.Enable(True)
 		self.disconnect_item.Enable(False)
 		self.mute_item.Check(False)
@@ -285,6 +287,7 @@ class GlobalPlugin(GlobalPlugin):
 		self.master_session = MasterSession(transport=transport, local_machine=self.local_machine)
 		transport.callback_manager.register_callback('transport_connected', self.on_connected_as_master)
 		transport.callback_manager.register_callback('transport_connection_failed', self.on_connected_as_master_failed)
+		transport.callback_manager.register_callback('transport_closing', self.disconnecting_as_master)
 		transport.callback_manager.register_callback('transport_disconnected', self.on_disconnected_from_slave)
 		self.master_transport = transport
 		self.master_transport.reconnector_thread.start()

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -278,7 +278,7 @@ class GlobalPlugin(GlobalPlugin):
 		ui.message(_("Connected!"))
 		beep_sequence.beep_sequence((440, 60), (660, 60))
 
-	def on_disconnected_from_slave(self):
+	def on_disconnected_as_master(self):
 		# Translators: Presented when connection to a remote computer was interupted.
 		ui.message(_("Connection interrupted"))
 
@@ -288,7 +288,7 @@ class GlobalPlugin(GlobalPlugin):
 		transport.callback_manager.register_callback('transport_connected', self.on_connected_as_master)
 		transport.callback_manager.register_callback('transport_connection_failed', self.on_connected_as_master_failed)
 		transport.callback_manager.register_callback('transport_closing', self.disconnecting_as_master)
-		transport.callback_manager.register_callback('transport_disconnected', self.on_disconnected_from_slave)
+		transport.callback_manager.register_callback('transport_disconnected', self.on_disconnected_as_master)
 		self.master_transport = transport
 		self.master_transport.reconnector_thread.start()
 

--- a/addon/globalPlugins/remoteClient/transport.py
+++ b/addon/globalPlugins/remoteClient/transport.py
@@ -34,6 +34,7 @@ class TCPTransport(Transport):
 		self.server_sock = None
 		self.queue_thread = None
 		self.timeout = timeout
+		self.reconnector_thread = ConnectorThread(self)
 
 	def run(self):
 		self.closed = False
@@ -125,8 +126,10 @@ class TCPTransport(Transport):
 
 	def close(self):
 		self.callback_manager.call_callbacks('transport_closing')
+		self.reconnector_thread.running = False
 		self._disconnect()
 		self.closed = True
+		self.reconnector_thread = ConnectorThread(self)
 
 class RelayTransport(TCPTransport):
 


### PR DESCRIPTION
Many method names have been changed to reflect what they actually do.
Specifically, many of the methods which handled various connection types were poorly-named and have now been fixed.
@tspivey and I have gone through and performed a large-scale code cleanup to make the code easier to understand and maintain.
