### PR TITLE
Auto connect settings on secure desktops are respected again

### DIFF
--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -69,7 +69,7 @@ class GlobalPlugin(GlobalPlugin):
 		self.ipc_file = os.path.join(self.temp_location, 'remote.ipc')
 		if globalVars.appArgs.secure:
 			self.handle_secure_desktop()
-		elif cs['autoconnect']:
+		if cs['autoconnect'] and not self.master_session and not self.slave_session:
 			self.perform_autoconnect()
 		self.sd_focused = False
 


### PR DESCRIPTION
This will only happen when there is not a master or slave session already, so a relay connection should always take precedence. This fixes unexpected behaviour which I created in #95.