### PR TITLE
Protocol version 2

### DIFF
--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -162,8 +162,7 @@ class GlobalPlugin(GlobalPlugin):
 		try:
 			connector.send(type='set_clipboard_text', text=api.getClipData())
 		except TypeError:
-			# JL: It might be helpful to provide a log.debug output for this.
-			pass
+			log.exception("Unable to push clipboard")
 
 	def on_options_item(self, evt):
 		evt.Skip()

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -302,7 +302,7 @@ class GlobalPlugin(GlobalPlugin):
 	def connected_to_relay(self):
 		log.info("Control connector connected")
 		beep_sequence.beep_sequence((720, 100), 50, (720, 100), 50, (720, 100))
-		# Transaltors: Presented in direct (client to server) remote connection when the controlled computer is ready.
+		# Translators: Presented in direct (client to server) remote connection when the controlled computer is ready.
 		speech.speakMessage(_("Connected to control server"))
 		self.push_clipboard_item.Enable(True)
 		write_connection_to_config(self.slave_transport.address)

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -188,7 +188,7 @@ class GlobalPlugin(GlobalPlugin):
 		if self.master_transport is not None:
 			self.disconnect_from_slave()
 		if self.slave_transport is not None:
-			self.disconnect_control()
+			self.disconnect_as_slave()
 		if self.server is not None:
 			self.server.close()
 			self.server = None
@@ -215,7 +215,7 @@ class GlobalPlugin(GlobalPlugin):
 			self.removeGestureBinding(REMOTE_KEY)
 		self.key_modified = False
 
-	def disconnect_control(self):
+	def disconnect_as_slave(self):
 		self.slave_transport.close()
 		self.slave_transport = None
 

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -78,7 +78,7 @@ class GlobalPlugin(GlobalPlugin):
 			self.start_control_server(port, channel)
 		else:
 			address = address_to_hostport(cs['host'])
-		self.connect_control(address, channel)
+		self.connect_as_slave(address, channel)
 
 	def create_menu(self):
 		self.menu = wx.Menu()
@@ -251,14 +251,14 @@ class GlobalPlugin(GlobalPlugin):
 				if dlg.connection_type.GetSelection() == 0:
 					self.connect_slave((server_addr, port), channel)
 				else:
-					self.connect_control((server_addr, port), channel)
+					self.connect_as_slave((server_addr, port), channel)
 			else: #We want a server
 				channel = dlg.panel.key.GetValue()
 				self.start_control_server(int(dlg.panel.port.GetValue()), channel)
 				if dlg.connection_type.GetSelection() == 0:
 					self.connect_slave(('127.0.0.1', int(dlg.panel.port.GetValue())), channel)
 				else:
-					self.connect_control(('127.0.0.1', int(dlg.panel.port.GetValue())), channel)
+					self.connect_as_slave(('127.0.0.1', int(dlg.panel.port.GetValue())), channel)
 		gui.runScriptModalDialog(dlg, callback=handle_dlg_complete)
 
 	def on_connected_to_slave(self):
@@ -289,7 +289,7 @@ class GlobalPlugin(GlobalPlugin):
 		self.master_transport = transport
 		self.master_transport.reconnector_thread.start()
 
-	def connect_control(self, address, key=None):
+	def connect_as_slave(self, address, key=None):
 		transport = RelayTransport(serializer=serializer.JSONSerializer(), address=address, channel=key)
 		self.slave_session = SlaveSession(transport=transport, local_machine=self.local_machine)
 		self.slave_transport = transport
@@ -391,7 +391,7 @@ class GlobalPlugin(GlobalPlugin):
 			test_socket=ssl.wrap_socket(test_socket)
 			test_socket.connect(('127.0.0.1', port))
 			test_socket.close()
-			self.connect_control(('127.0.0.1', port), channel)
+			self.connect_as_slave(('127.0.0.1', port), channel)
 			return True
 		except:
 			return False

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -110,7 +110,7 @@ class GlobalPlugin(GlobalPlugin):
 		self.remote_item=tools_menu.AppendSubMenu(self.menu, _("R&emote"), _("NVDA Remote Access"))
 
 	def terminate(self):
-		self.do_disconnect_from_slave()
+		self.disconnect()
 		self.local_machine = None
 		self.menu.RemoveItem(self.connect_item)
 		self.connect_item.Destroy()
@@ -146,7 +146,7 @@ class GlobalPlugin(GlobalPlugin):
 
 	def on_disconnect_item(self, evt):
 		evt.Skip()
-		self.do_disconnect_from_slave()
+		self.disconnect()
 
 	def on_mute_item(self, evt):
 		evt.Skip()
@@ -180,7 +180,7 @@ class GlobalPlugin(GlobalPlugin):
 	def on_send_ctrl_alt_del(self, evt):
 		self.master_transport.send('send_SAS')
 
-	def do_disconnect_from_slave(self):
+	def disconnect(self):
 		if self.master_transport is None and self.slave_transport is None:
 			return
 		if self.master_transport is not None:
@@ -229,7 +229,7 @@ class GlobalPlugin(GlobalPlugin):
 		if self.master_transport is None and self.slave_transport is None:
 			ui.message(_("Not connected."))
 			return
-		self.do_disconnect_from_slave()
+		self.disconnect()
 	script_disconnect.__doc__ = _("""Disconnect a remote session""")
 
 	def do_connect(self, evt):

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -110,7 +110,7 @@ class GlobalPlugin(GlobalPlugin):
 		self.remote_item=tools_menu.AppendSubMenu(self.menu, _("R&emote"), _("NVDA Remote Access"))
 
 	def terminate(self):
-		self.do_disconnect_from_slave(True)
+		self.do_disconnect_from_slave()
 		self.local_machine = None
 		self.menu.RemoveItem(self.connect_item)
 		self.connect_item.Destroy()
@@ -180,10 +180,8 @@ class GlobalPlugin(GlobalPlugin):
 	def on_send_ctrl_alt_del(self, evt):
 		self.master_transport.send('send_SAS')
 
-	def do_disconnect_from_slave(self, quiet=False):
+	def do_disconnect_from_slave(self):
 		if self.master_transport is None and self.slave_transport is None:
-			if not quiet:
-				ui.message(_("Not connected."))
 			return
 		if self.master_transport is not None:
 			self.disconnect_as_master()
@@ -228,6 +226,9 @@ class GlobalPlugin(GlobalPlugin):
 			message=_("Unable to connect to the remote computer"), style=wx.OK | wx.ICON_WARNING)
 
 	def script_disconnect(self, gesture):
+		if self.master_transport is None and self.slave_transport is None:
+			ui.message(_("Not connected."))
+			return
 		self.do_disconnect_from_slave()
 	script_disconnect.__doc__ = _("""Disconnect a remote session""")
 

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -261,7 +261,7 @@ class GlobalPlugin(GlobalPlugin):
 					self.connect_as_slave(('127.0.0.1', int(dlg.panel.port.GetValue())), channel)
 		gui.runScriptModalDialog(dlg, callback=handle_dlg_complete)
 
-	def on_connected_to_slave(self):
+	def on_connected_as_master(self):
 		write_connection_to_config(self.master_transport.address)
 		self.disconnect_item.Enable(True)
 		self.connect_item.Enable(False)
@@ -283,7 +283,7 @@ class GlobalPlugin(GlobalPlugin):
 	def connect_as_master(self, address, channel):
 		transport = RelayTransport(address=address, serializer=serializer.JSONSerializer(), channel=channel)
 		self.master_session = MasterSession(transport=transport, local_machine=self.local_machine)
-		transport.callback_manager.register_callback('transport_connected', self.on_connected_to_slave)
+		transport.callback_manager.register_callback('transport_connected', self.on_connected_as_master)
 		transport.callback_manager.register_callback('transport_connection_failed', self.on_slave_connection_failed)
 		transport.callback_manager.register_callback('transport_disconnected', self.on_disconnected_from_slave)
 		self.master_transport = transport

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -186,7 +186,7 @@ class GlobalPlugin(GlobalPlugin):
 				ui.message(_("Not connected."))
 			return
 		if self.master_transport is not None:
-			self.disconnect_from_slave()
+			self.disconnect_as_master()
 		if self.slave_transport is not None:
 			self.disconnect_as_slave()
 		if self.server is not None:
@@ -197,7 +197,7 @@ class GlobalPlugin(GlobalPlugin):
 		self.connect_item.Enable(True)
 		self.push_clipboard_item.Enable(False)
 
-	def disconnect_from_slave(self):
+	def disconnect_as_master(self):
 		self.master_transport.close()
 		self.master_transport = None
 		self.connect_item.Enable(True)
@@ -221,7 +221,7 @@ class GlobalPlugin(GlobalPlugin):
 
 	def on_slave_connection_failed(self):
 		if self.master_transport.successful_connects == 0:
-			self.disconnect_from_slave()
+			self.disconnect_as_master()
 			# Translators: Title of the connection error dialog.
 			gui.messageBox(parent=gui.mainFrame, caption=_("Error Connecting"),
 			# Translators: Message shown when cannot connect to the remote computer.

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -296,12 +296,12 @@ class GlobalPlugin(GlobalPlugin):
 		transport = RelayTransport(serializer=serializer.JSONSerializer(), address=address, channel=key)
 		self.slave_session = SlaveSession(transport=transport, local_machine=self.local_machine)
 		self.slave_transport = transport
-		self.slave_transport.callback_manager.register_callback('transport_connected', self.connected_to_relay)
+		self.slave_transport.callback_manager.register_callback('transport_connected', self.on_connected_as_slave)
 		self.slave_transport.reconnector_thread.start()
 		self.disconnect_item.Enable(True)
 		self.connect_item.Enable(False)
 
-	def connected_to_relay(self):
+	def on_connected_as_slave(self):
 		log.info("Control connector connected")
 		beep_sequence.beep_sequence((720, 100), 50, (720, 100), 50, (720, 100))
 		# Translators: Presented in direct (client to server) remote connection when the controlled computer is ready.

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -249,14 +249,14 @@ class GlobalPlugin(GlobalPlugin):
 				server_addr, port = address_to_hostport(server_addr)
 				channel = dlg.panel.key.GetValue()
 				if dlg.connection_type.GetSelection() == 0:
-					self.connect_slave((server_addr, port), channel)
+					self.connect_as_master((server_addr, port), channel)
 				else:
 					self.connect_as_slave((server_addr, port), channel)
 			else: #We want a server
 				channel = dlg.panel.key.GetValue()
 				self.start_control_server(int(dlg.panel.port.GetValue()), channel)
 				if dlg.connection_type.GetSelection() == 0:
-					self.connect_slave(('127.0.0.1', int(dlg.panel.port.GetValue())), channel)
+					self.connect_as_master(('127.0.0.1', int(dlg.panel.port.GetValue())), channel)
 				else:
 					self.connect_as_slave(('127.0.0.1', int(dlg.panel.port.GetValue())), channel)
 		gui.runScriptModalDialog(dlg, callback=handle_dlg_complete)
@@ -280,7 +280,7 @@ class GlobalPlugin(GlobalPlugin):
 		# Translators: Presented when connection to a remote computer was interupted.
 		ui.message(_("Connection interrupted"))
 
-	def connect_slave(self, address, channel):
+	def connect_as_master(self, address, channel):
 		transport = RelayTransport(address=address, serializer=serializer.JSONSerializer(), channel=channel)
 		self.master_session = MasterSession(transport=transport, local_machine=self.local_machine)
 		transport.callback_manager.register_callback('transport_connected', self.on_connected_to_slave)

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -216,7 +216,7 @@ class GlobalPlugin(GlobalPlugin):
 		self.slave_transport.close()
 		self.slave_transport = None
 
-	def on_slave_connection_failed(self):
+	def on_connected_as_master_failed(self):
 		if self.master_transport.successful_connects == 0:
 			self.disconnect_as_master()
 			# Translators: Title of the connection error dialog.
@@ -284,7 +284,7 @@ class GlobalPlugin(GlobalPlugin):
 		transport = RelayTransport(address=address, serializer=serializer.JSONSerializer(), channel=channel)
 		self.master_session = MasterSession(transport=transport, local_machine=self.local_machine)
 		transport.callback_manager.register_callback('transport_connected', self.on_connected_as_master)
-		transport.callback_manager.register_callback('transport_connection_failed', self.on_slave_connection_failed)
+		transport.callback_manager.register_callback('transport_connection_failed', self.on_connected_as_master_failed)
 		transport.callback_manager.register_callback('transport_disconnected', self.on_disconnected_from_slave)
 		self.master_transport = transport
 		self.master_transport.reconnector_thread.start()

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -197,6 +197,8 @@ class GlobalPlugin(GlobalPlugin):
 	def disconnect_as_master(self):
 		self.master_transport.close()
 		self.master_transport = None
+
+	def disconnecting_as_master(self):
 		self.connect_item.Enable(True)
 		self.disconnect_item.Enable(False)
 		self.mute_item.Check(False)
@@ -285,6 +287,7 @@ class GlobalPlugin(GlobalPlugin):
 		self.master_session = MasterSession(transport=transport, local_machine=self.local_machine)
 		transport.callback_manager.register_callback('transport_connected', self.on_connected_as_master)
 		transport.callback_manager.register_callback('transport_connection_failed', self.on_connected_as_master_failed)
+		transport.callback_manager.register_callback('transport_closing', self.disconnecting_as_master)
 		transport.callback_manager.register_callback('transport_disconnected', self.on_disconnected_from_slave)
 		self.master_transport = transport
 		self.master_transport.reconnector_thread.start()

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -278,7 +278,7 @@ class GlobalPlugin(GlobalPlugin):
 		ui.message(_("Connected!"))
 		beep_sequence.beep_sequence((440, 60), (660, 60))
 
-	def on_disconnected_from_slave(self):
+	def on_disconnected_as_master(self):
 		# Translators: Presented when connection to a remote computer was interupted.
 		ui.message(_("Connection interrupted"))
 
@@ -288,7 +288,7 @@ class GlobalPlugin(GlobalPlugin):
 		transport.callback_manager.register_callback('transport_connected', self.on_connected_as_master)
 		transport.callback_manager.register_callback('transport_connection_failed', self.on_connected_as_master_failed)
 		transport.callback_manager.register_callback('transport_closing', self.disconnecting_as_master)
-		transport.callback_manager.register_callback('transport_disconnected', self.on_disconnected_from_slave)
+		transport.callback_manager.register_callback('transport_disconnected', self.on_disconnected_as_master)
 		self.master_transport = transport
 		self.master_transport.reconnector_thread.start()
 

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -283,7 +283,7 @@ class GlobalPlugin(GlobalPlugin):
 		ui.message(_("Connection interrupted"))
 
 	def connect_as_master(self, address, channel):
-		transport = RelayTransport(address=address, serializer=serializer.JSONSerializer(), channel=channel)
+		transport = RelayTransport(address=address, serializer=serializer.JSONSerializer(), channel=channel, connection_type='master')
 		self.master_session = MasterSession(transport=transport, local_machine=self.local_machine)
 		transport.callback_manager.register_callback('transport_connected', self.on_connected_as_master)
 		transport.callback_manager.register_callback('transport_connection_failed', self.on_connected_as_master_failed)
@@ -293,7 +293,7 @@ class GlobalPlugin(GlobalPlugin):
 		self.master_transport.reconnector_thread.start()
 
 	def connect_as_slave(self, address, key=None):
-		transport = RelayTransport(serializer=serializer.JSONSerializer(), address=address, channel=key)
+		transport = RelayTransport(serializer=serializer.JSONSerializer(), address=address, channel=key, connection_type='slave')
 		self.slave_session = SlaveSession(transport=transport, local_machine=self.local_machine)
 		self.slave_transport = transport
 		self.slave_transport.callback_manager.register_callback('transport_connected', self.on_connected_as_slave)

--- a/addon/globalPlugins/remoteClient/local_machine.py
+++ b/addon/globalPlugins/remoteClient/local_machine.py
@@ -44,8 +44,8 @@ class LocalMachine(object):
 	def send_key(self, vk_code=None, extended=None, pressed=None, **kwargs):
 		wx.CallAfter(input.send_key, vk_code, None, extended, pressed)
 
-	def set_clipboard_text(self, text):
+	def set_clipboard_text(self, text, **kwargs):
 		api.copyToClip(text=text)
 
-	def send_SAS(self):
+	def send_SAS(self, **kwargs):
 		ctypes.windll.sas.SendSAS(0)

--- a/addon/globalPlugins/remoteClient/local_machine.py
+++ b/addon/globalPlugins/remoteClient/local_machine.py
@@ -17,24 +17,24 @@ class LocalMachine(object):
 		self.is_muted = False
 		self.patcher = nvda_patcher.NVDAPatcher()
 
-	def play_wave(self, fileName, async):
+	def play_wave(self, fileName, async, **kwargs):
 		if self.is_muted:
 			return
 		if os.path.exists(fileName):
 			nvwave.playWaveFile(fileName=fileName, async=async)
 
-	def beep(self, hz, length, left, right):
+	def beep(self, hz, length, left, right, **kwargs):
 		if self.is_muted:
 			return
 		tones.beep(hz, length, left, right)
 
-	def cancel_speech(self):
+	def cancel_speech(self, **kwargs):
 		if self.is_muted:
 			return
 		synth = speech.getSynth()
 		wx.CallAfter(synth.cancel)
 
-	def speak(self, sequence):
+	def speak(self, sequence, **kwargs):
 		if self.is_muted:
 			return
 		synth = speech.getSynth()

--- a/addon/globalPlugins/remoteClient/server.py
+++ b/addon/globalPlugins/remoteClient/server.py
@@ -62,7 +62,7 @@ class Server(object):
 	def client_disconnected(self, client):
 		self.remove_client(client)
 		if client.authenticated:
-			client.send_to_others(type='client_left', user_id=client.id)
+			client.send_to_others(type='client_left', user_id=client.id, client=client.as_dict())
 
 	def close(self):
 		self.running = False
@@ -77,6 +77,7 @@ class Client(object):
 		self.buffer = ""
 		self.authenticated = False
 		self.id = Client.id + 1
+		self.connection_type = None
 		self.protocol_version = 1
 		Client.id += 1
 
@@ -113,6 +114,9 @@ class Client(object):
 		if hasattr(self, fn):
 			getattr(self, fn)(parsed)
 
+	def as_dict(self):
+		return dict(id=self.id, type=self.connection_type)
+
 	def do_join(self, obj):
 		password = obj.get('channel', None)
 		if password != self.server.password:
@@ -120,9 +124,15 @@ class Client(object):
 			self.close()
 			return
 		self.authenticated = True
-		clients = [c.id for c in self.server.clients.values() if c.authenticated and c is not self]
-		self.send(type='channel_joined', channel=self.server.password, user_ids=clients)
-		self.send_to_others(type='client_joined', user_id=self.id)
+		clients = []
+		client_ids = []
+		for c in self.server.clients.values():
+			if c is self or not c.authenticated:
+				continue
+			clients.append(c.as_dict())
+			client_ids.append(c.id)
+		self.send(type='channel_joined', channel=self.server.password, user_ids=client_ids, clients=clients)
+		self.send_to_others(type='client_joined', user_id=self.id, client=self.as_dict())
 
 	def do_protocol_version(self, obj):
 		version = obj.get('version')
@@ -134,10 +144,15 @@ class Client(object):
 		self.socket.close()
 		self.server.client_disconnected(self)
 
-	def send(self, type, origin=None, **kwargs):
+	def send(self, type, origin=None, clients=None, client=None, **kwargs):
 		msg = dict(type=type, **kwargs)
-		if self.protocol_version > 1 and origin:
-			msg['origin'] = origin
+		if self.protocol_version > 1:
+			if origin:
+				msg['origin'] = origin
+			if clients:
+				msg['clients'] = clients
+			if client:
+				msg['client'] = client
 		msgstr = json.dumps(msg)+"\n"
 		try:
 			self.socket.sendall(msgstr)

--- a/addon/globalPlugins/remoteClient/server.py
+++ b/addon/globalPlugins/remoteClient/server.py
@@ -123,6 +123,7 @@ class Client(object):
 			self.send(type='error', message='incorrect_password')
 			self.close()
 			return
+		self.connection_type = obj.get('connection_type')
 		self.authenticated = True
 		clients = []
 		client_ids = []

--- a/addon/globalPlugins/remoteClient/server.py
+++ b/addon/globalPlugins/remoteClient/server.py
@@ -115,7 +115,7 @@ class Client(object):
 			getattr(self, fn)(parsed)
 
 	def as_dict(self):
-		return dict(id=self.id, type=self.connection_type)
+		return dict(id=self.id, connection_type=self.connection_type)
 
 	def do_join(self, obj):
 		password = obj.get('channel', None)

--- a/addon/globalPlugins/remoteClient/server.py
+++ b/addon/globalPlugins/remoteClient/server.py
@@ -144,7 +144,9 @@ class Client(object):
 		except:
 			self.close()
 
-	def send_to_others(self, **obj):
+	def send_to_others(self, origin=None, **obj):
+		if origin is None:
+			origin = self.id
 		for c in self.server.clients.itervalues():
 			if c is not self and c.authenticated:
-				c.send(origin=self.id, **obj)
+				c.send(origin=origin, **obj)

--- a/addon/globalPlugins/remoteClient/session.py
+++ b/addon/globalPlugins/remoteClient/session.py
@@ -35,7 +35,7 @@ class SlaveSession(RemoteSession):
 		self.local_machine.patcher.orig_beep(1000, 300)
 		self.masters[user_id] = True
 
-	def handle_channel_joined(self, channel=None, user_ids=None, origin=None):
+	def handle_channel_joined(self, channel=None, user_ids=None, origin=None, **kwargs):
 		for user in user_ids:
 			self.handle_client_connected(user_id=user)
 
@@ -81,7 +81,7 @@ class SlaveSession(RemoteSession):
 	def playWaveFile(self, fileName, async=True):
 		self.transport.send(type='wave', fileName=fileName, async=async)
 
-	def update_index(self, index=None, **msg):
+	def update_index(self, index=None, **kwargs):
 		self.last_client_index = index
 
 class MasterSession(RemoteSession):

--- a/addon/globalPlugins/remoteClient/session.py
+++ b/addon/globalPlugins/remoteClient/session.py
@@ -9,6 +9,14 @@ class RemoteSession(object):
 	def __init__(self, local_machine, transport):
 		self.local_machine = local_machine
 		self.transport = transport
+		self.transport.callback_manager.register_callback('msg_version_mismatch', self.handle_version_mismatch)
+
+	def handle_version_mismatch(self, **kwargs):
+		#translators: Message for version mismatch
+		message = _("""The version of the relay server which you have connected to is not compatible with this version of the Remote Client.
+Please either use a different server or upgrade your version of the addon.""")
+		ui.message(message)
+		self.transport.close()
 
 class SlaveSession(RemoteSession):
 	"""Session that runs on the slave and manages state."""

--- a/addon/globalPlugins/remoteClient/session.py
+++ b/addon/globalPlugins/remoteClient/session.py
@@ -35,7 +35,7 @@ class SlaveSession(RemoteSession):
 		self.local_machine.patcher.orig_beep(1000, 300)
 		self.masters[user_id] = True
 
-	def handle_channel_joined(self, channel=None, user_ids=None):
+	def handle_channel_joined(self, channel=None, user_ids=None, origin=None):
 		for user in user_ids:
 			self.handle_client_connected(user_id=user)
 
@@ -81,7 +81,7 @@ class SlaveSession(RemoteSession):
 	def playWaveFile(self, fileName, async=True):
 		self.transport.send(type='wave', fileName=fileName, async=async)
 
-	def update_index(self, index=None):
+	def update_index(self, index=None, **msg):
 		self.last_client_index = index
 
 class MasterSession(RemoteSession):
@@ -116,14 +116,14 @@ class MasterSession(RemoteSession):
 	def handle_disconnected(self):
 		self.index_thread = None
 
-	def handle_channel_joined(self, channel=None, user_ids=None):
+	def handle_channel_joined(self, channel=None, user_ids=None, origin=None, **kwargs):
 		for user in user_ids:
 			self.handle_client_connected(user_id=user)
 
-	def handle_client_connected(self, user_id=None):
+	def handle_client_connected(self, user_id=None, **kwargs):
 		tones.beep(1000, 300)
 
-	def handle_client_disconnected(self, user_id=None):
+	def handle_client_disconnected(self, user_id=None, **kwargs):
 		tones.beep(108, 300)
 
 	def send_indexes(self):

--- a/addon/globalPlugins/remoteClient/session.py
+++ b/addon/globalPlugins/remoteClient/session.py
@@ -54,9 +54,10 @@ class SlaveSession(RemoteSession):
 
 	def handle_client_disconnected(self, client=None, **kwargs):
 		self.local_machine.patcher.orig_beep(108, 300)
-		del self.masters[client['id']]
 		if not self.masters:
 			self.local_machine.patcher.unpatch()
+		if client['connection_type'] == 'master':
+			del self.masters[client['id']]
 
 	def add_patch_callbacks(self):
 		patcher_callbacks = (('speak', self.speak), ('beep', self.beep), ('wave', self.playWaveFile), ('cancel_speech', self.cancel_speech))

--- a/addon/globalPlugins/remoteClient/transport.py
+++ b/addon/globalPlugins/remoteClient/transport.py
@@ -9,6 +9,9 @@ from logging import getLogger
 log = getLogger('transport')
 import callback_manager
 
+PROTOCOL_VERSION = 2
+
+
 class Transport(object):
 
 	def __init__(self, serializer):
@@ -133,13 +136,15 @@ class TCPTransport(Transport):
 
 class RelayTransport(TCPTransport):
 
-	def __init__(self, serializer, address, timeout=0, channel=None):
+	def __init__(self, serializer, address, timeout=0, channel=None, protocol_version=PROTOCOL_VERSION):
 		super(RelayTransport, self).__init__(address=address, serializer=serializer, timeout=timeout)
 		log.info("Connecting to %s channel %s" % (address, channel))
 		self.channel = channel
+		self.protocol_version = protocol_version
 		self.callback_manager.register_callback('transport_connected', self.on_connected)
 
 	def on_connected(self):
+		self.send('protocol_version', version=self.protocol_version)
 		if self.channel is not None:
 			self.send('join', channel=self.channel)
 		else:

--- a/addon/globalPlugins/remoteClient/transport.py
+++ b/addon/globalPlugins/remoteClient/transport.py
@@ -136,17 +136,18 @@ class TCPTransport(Transport):
 
 class RelayTransport(TCPTransport):
 
-	def __init__(self, serializer, address, timeout=0, channel=None, protocol_version=PROTOCOL_VERSION):
+	def __init__(self, serializer, address, timeout=0, channel=None, connection_type=None, protocol_version=PROTOCOL_VERSION):
 		super(RelayTransport, self).__init__(address=address, serializer=serializer, timeout=timeout)
 		log.info("Connecting to %s channel %s" % (address, channel))
 		self.channel = channel
+		self.connection_type = connection_type
 		self.protocol_version = protocol_version
 		self.callback_manager.register_callback('transport_connected', self.on_connected)
 
 	def on_connected(self):
 		self.send('protocol_version', version=self.protocol_version)
 		if self.channel is not None:
-			self.send('join', channel=self.channel)
+			self.send('join', channel=self.channel, connection_type=self.connection_type)
 		else:
 			self.send('generate_key')
 


### PR DESCRIPTION
Significant but backwards compatible changes to the remote protocol.
Now, each message which comes from a remote machine has an origin field containing its remote id.
When joining a channel, or when other machines join, these ids and their corresponding connection types are communicated.
This allows us to see exactly who is controlling what, and lays the groundwork for fixing several issues.
Specifically, this fixes #93 and lays the groundwork to be able to implement #65 and #67