### PR TITLE
Dialogs: center connect and options dialogs

### DIFF
--- a/addon/globalPlugins/remoteClient/dialogs.py
+++ b/addon/globalPlugins/remoteClient/dialogs.py
@@ -138,6 +138,7 @@ class DirectConnectDialog(wx.Dialog):
 		main_sizer.Add(buttons, flag=wx.BOTTOM)
 		main_sizer.Fit(self)
 		self.SetSizer(main_sizer)
+		self.Center(wx.BOTH | wx.CENTER_ON_SCREEN)
 		ok = wx.FindWindowById(wx.ID_OK, self)
 		ok.Bind(wx.EVT_BUTTON, self.on_ok)
 
@@ -196,6 +197,7 @@ class OptionsDialog(wx.Dialog):
 		main_sizer.Add(buttons, flag=wx.BOTTOM)
 		main_sizer.Fit(self)
 		self.SetSizer(main_sizer)
+		self.Center(wx.BOTH | wx.CENTER_ON_SCREEN)
 		ok = wx.FindWindowById(wx.ID_OK, self)
 		ok.Bind(wx.EVT_BUTTON, self.on_ok)
 		self.autoconnect.SetFocus()


### PR DESCRIPTION
PR for #99:

Previously, Connect and Options dialogs were on the top-left portion of the screen. For consistency with other NVDA windows, center these dialogs. Thankfully, panels inside Connect dialog will also be centered on screen because wx.Dialog.Center will be used to center the whole dialog.