### PR TITLE
Properly destroy the url handler window on plugin termination

### DIFF
--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -161,6 +161,8 @@ class GlobalPlugin(GlobalPlugin):
 		self.menu=None
 		if not isInstalledCopy():
 			url_handler.unregister_url_handler()
+		self.url_handler_window.destroy()
+		self.url_handler_window=None
 
 	def on_disconnect_item(self, evt):
 		evt.Skip()


### PR DESCRIPTION
Not doing this created errors when reloading plugins