### PR TITLE
Fix braille input gestures when slave is in browse mode (#136)

### DIFF
--- a/addon/globalPlugins/remoteClient/input.py
+++ b/addon/globalPlugins/remoteClient/input.py
@@ -95,8 +95,8 @@ class BrailleInputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInp
 		treeInterceptor = focus.treeInterceptor
 		if treeInterceptor and treeInterceptor.isReady:
 			func = getattr(treeInterceptor , "script_%s" % scriptName, None)
-			# We are no keyboard input
-			return func
+			if func:
+				return func
 
 		# NVDAObject level.
 		func = getattr(focus, "script_%s" % scriptName, None)


### PR DESCRIPTION
Braille input gestures didn't work when the slave was in browse mode, since we were just ignoring all the global commands due to a silly mistake I made. Now, only return a function if there is a real function to return, else continue the search for scripts