### PR TITLE
Fixed errors on plugin termination (#134)

### DIFF
--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -243,21 +243,16 @@ class GlobalPlugin(GlobalPlugin):
 		self.master_session = None
 
 	def disconnecting_as_master(self):
-		if self.connect_item:
+		if self.menu:
 			self.connect_item.Enable(True)
-		if self.disconnect_item:
 			self.disconnect_item.Enable(False)
-		if self.mute_item:
 			self.mute_item.Check(False)
 			self.mute_item.Enable(False)
+			self.push_clipboard_item.Enable(False)
+			self.copy_link_item.Enable(False)
+			self.send_ctrl_alt_del_item.Enable(False)
 		if self.local_machine:
 			self.local_machine.is_muted = False
-		if self.push_clipboard_item:
-			self.push_clipboard_item.Enable(False)
-		if self.copy_link_item:
-			self.copy_link_item.Enable(False)
-		if self.send_ctrl_alt_del_item:
-			self.send_ctrl_alt_del_item.Enable(False)
 		self.sending_keys = False
 		if self.hook_thread is not None:
 			ctypes.windll.user32.PostThreadMessageW(self.hook_thread.ident, win32con.WM_QUIT, 0, 0)

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -243,14 +243,21 @@ class GlobalPlugin(GlobalPlugin):
 		self.master_session = None
 
 	def disconnecting_as_master(self):
-		self.connect_item.Enable(True)
-		self.disconnect_item.Enable(False)
-		self.mute_item.Check(False)
-		self.mute_item.Enable(False)
-		self.local_machine.is_muted = False
-		self.push_clipboard_item.Enable(False)
-		self.copy_link_item.Enable(False)
-		self.send_ctrl_alt_del_item.Enable(False)
+		if self.connect_item:
+			self.connect_item.Enable(True)
+		if self.disconnect_item:
+			self.disconnect_item.Enable(False)
+		if self.mute_item:
+			self.mute_item.Check(False)
+			self.mute_item.Enable(False)
+		if self.local_machine:
+			self.local_machine.is_muted = False
+		if self.push_clipboard_item:
+			self.push_clipboard_item.Enable(False)
+		if self.copy_link_item:
+			self.copy_link_item.Enable(False)
+		if self.send_ctrl_alt_del_item:
+			self.send_ctrl_alt_del_item.Enable(False)
 		self.sending_keys = False
 		if self.hook_thread is not None:
 			ctypes.windll.user32.PostThreadMessageW(self.hook_thread.ident, win32con.WM_QUIT, 0, 0)


### PR DESCRIPTION
IN disconnecting_as_master, we now check the existence of some objects before we try to do something with them, particularly menu items