### PR TITLE
Support model specific braille display gestures

### DIFF
--- a/addon/globalPlugins/remoteClient/nvda_patcher.py
+++ b/addon/globalPlugins/remoteClient/nvda_patcher.py
@@ -236,6 +236,8 @@ class NVDAMasterPatcher(NVDAPatcher):
 					dict["scriptPath"]=[scriptData[0].__module__,scriptData[0].__name__,scriptData[1]]
 			if hasattr(gesture,"source") and "source" not in dict:
 				dict["source"]=gesture.source
+			if hasattr(gesture,"model") and "model" not in dict:
+				dict["model"]=gesture.model
 			if hasattr(gesture,"id") and "id" not in dict:
 				dict["id"]=gesture.id
 			elif hasattr(gesture,"identifiers") and "identifiers" not in dict:


### PR DESCRIPTION
This adds support for nvaccess/nvda#7517 and is backwards compatible. Note that model specific gestures will already work in most cases, they won't work in case the model is retrieved using a AutoProperty style getter though.