### PR TITLE
Fix imports for Braille

### DIFF
--- a/addon/globalPlugins/remoteClient/input.py
+++ b/addon/globalPlugins/remoteClient/input.py
@@ -14,6 +14,7 @@ import scriptHandler
 import inputCore
 import api
 import vision
+import baseObject
 
 INPUT_MOUSE = 0
 INPUT_KEYBOARD = 1


### PR DESCRIPTION
Hi,
for a lot of time, as showed from #222, Braille has had problems in scrolling lines, for simple missed imports (baseObject in these sources, baseObject and vision in site hosted package).
This pr fixes it.
So, a new add-on release (with upgraded version to avoid confusion) would be very, very welcome.