### PR TITLE
Add a SSL certificate hostname and CA chain verification

### DIFF
--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -357,8 +357,14 @@ class GlobalPlugin(_GlobalPlugin):
 		self.disconnect()
 		try:
 			cert_hash = transport.last_fail_fingerprint
-			message = _("Warning! The certificate of this server could not be verified.\nThis connection may not be secure. It is possible that someone is trying to overhear your communication.\nBefore continuing please make sure that the following server certificate fingerprint is a proper one.\nIf you have any questions, please contact the server administrator.\n\nServer SHA256 fingerprint: {fingerprint}\n\nDo you want to continue connecting?").format(fingerprint=cert_hash)
-			if gui.messageBox(message, _("NVDA Remote Connection Security Warning"), wx.YES|wx.NO|wx.NO_DEFAULT|wx.ICON_WARNING) == wx.YES: return True
+				
+			wnd = dialogs.CertificateUnauthorizedDialog(None, fingerprint=cert_hash)
+			a = wnd.ShowModal()
+			if a == wx.ID_YES:
+				config = configuration.get_config()
+				config['trusted_certs'][hostport_to_address(self.last_fail_address)]=cert_hash
+				config.write()
+			if a == wx.ID_YES or a == wx.ID_NO: return True
 		except Exception as ex:
 			log.error(ex)
 		return False

--- a/addon/globalPlugins/remoteClient/configuration.py
+++ b/addon/globalPlugins/remoteClient/configuration.py
@@ -23,6 +23,9 @@ configspec = StringIO("""
 
 [seen_motds]
 	__many__ = string(default="")
+
+[trusted_certs]
+	__many__ = string(default="")
 """)
 def get_config():
 	global _config

--- a/addon/globalPlugins/remoteClient/dialogs.py
+++ b/addon/globalPlugins/remoteClient/dialogs.py
@@ -258,3 +258,13 @@ class OptionsDialog(wx.Dialog):
 			cs['port'] = int(self.port.GetValue())
 		cs['key'] = self.key.GetValue()
 		config.write()
+
+class CertificateUnauthorizedDialog(wx.MessageDialog):
+
+	def __init__(self, parent, fingerprint=None):
+		# Translators: A title bar of a window presented when an attempt has been made to connect with a server with unauthorized certificate.
+		title=_("NVDA Remote Connection Security Warning")
+		# Translators: A message of a window presented when an attempt has been made to connect with a server with unauthorized certificate.
+		message = _("Warning! The certificate of this server could not be verified.\nThis connection may not be secure. It is possible that someone is trying to overhear your communication.\nBefore continuing please make sure that the following server certificate fingerprint is a proper one.\nIf you have any questions, please contact the server administrator.\n\nServer SHA256 fingerprint: {fingerprint}\n\nDo you want to continue connecting?").format(fingerprint=fingerprint)
+		super().__init__(parent, caption=title, message=message, style=wx.YES_NO|wx.CANCEL|wx.CANCEL_DEFAULT|wx.CENTRE)
+		self.SetYesNoLabels(_("Connect and do not ask again for this server"), _("Connect"))

--- a/addon/globalPlugins/remoteClient/dialogs.py
+++ b/addon/globalPlugins/remoteClient/dialogs.py
@@ -16,6 +16,7 @@ except addonHandler.AddonError:
 	log.warning(
 		"Unable to initialise translations. This may be because the addon is running from NVDA scratchpad."
 	)
+from . import configuration
 
 WX_VERSION = int(wx.version()[0])
 WX_CENTER = wx.Center if WX_VERSION>=4 else wx.CENTER_ON_SCREEN
@@ -198,6 +199,10 @@ class OptionsDialog(wx.Dialog):
 		self.key = wx.TextCtrl(self, wx.ID_ANY)
 		self.key.Enable(False)
 		main_sizer.Add(self.key)
+		# Translators: A button in add-on options dialog to delete all fingerprints of unauthorized certificates.
+		self.delete_fingerprints = wx.Button(self, wx.ID_ANY, label=_("Delete all trusted fingerprints"))
+		self.delete_fingerprints.Bind(wx.EVT_BUTTON, self.on_delete_fingerprints)
+		main_sizer.Add(self.delete_fingerprints)
 		buttons = self.CreateButtonSizer(wx.OK | wx.CANCEL)
 		main_sizer.Add(buttons, flag=wx.BOTTOM)
 		main_sizer.Fit(self)
@@ -233,6 +238,13 @@ class OptionsDialog(wx.Dialog):
 		self.port.SetValue(str(cs['port']))
 		self.key.SetValue(cs['key'])
 		self.set_controls()
+
+	def on_delete_fingerprints(self, evt):
+		if gui.messageBox(_("When connecting to an authorized server, you will again be prompted to accepts its certificate."), _("Are you sure you want to delete all stored trusted fingerprints?"), wx.YES|wx.NO|wx.NO_DEFAULT|wx.ICON_WARNING) == wx.YES:
+			config = configuration.get_config()
+			config['trusted_certs'].clear()
+			config.write()
+		evt.skip()
 
 	def on_ok(self, evt):
 		if self.autoconnect.GetValue():

--- a/addon/globalPlugins/remoteClient/dialogs.py
+++ b/addon/globalPlugins/remoteClient/dialogs.py
@@ -240,7 +240,7 @@ class OptionsDialog(wx.Dialog):
 		self.set_controls()
 
 	def on_delete_fingerprints(self, evt):
-		if gui.messageBox(_("When connecting to an authorized server, you will again be prompted to accepts its certificate."), _("Are you sure you want to delete all stored trusted fingerprints?"), wx.YES|wx.NO|wx.NO_DEFAULT|wx.ICON_WARNING) == wx.YES:
+		if gui.messageBox(_("When connecting to an unauthorized server, you will again be prompted to accepts its certificate."), _("Are you sure you want to delete all stored trusted fingerprints?"), wx.YES|wx.NO|wx.NO_DEFAULT|wx.ICON_WARNING) == wx.YES:
 			config = configuration.get_config()
 			config['trusted_certs'].clear()
 			config.write()

--- a/addon/globalPlugins/remoteClient/transport.py
+++ b/addon/globalPlugins/remoteClient/transport.py
@@ -62,7 +62,7 @@ class TCPTransport(Transport):
 				fingerprint = hashlib.sha256(certBin).hexdigest().lower()
 			except Exception: pass
 			config = configuration.get_config()
-			if hostport_to_address(self.address) in config['trusted_certs'][hostport_to_address(self.address)]==fingerprint:
+			if hostport_to_address(self.address) in config['trusted_certs'] and config['trusted_certs'][hostport_to_address(self.address)]==fingerprint:
 				self.insecure=True
 				return self.run()
 			self.last_fail_fingerprint = fingerprint

--- a/addon/globalPlugins/remoteClient/transport.py
+++ b/addon/globalPlugins/remoteClient/transport.py
@@ -9,6 +9,8 @@ from collections import defaultdict
 from logging import getLogger
 log = getLogger('transport')
 from . import callback_manager
+from . import configuration
+from .socket_utils import SERVER_PORT, address_to_hostport, hostport_to_address
 
 PROTOCOL_VERSION: int = 2
 
@@ -59,6 +61,10 @@ class TCPTransport(Transport):
 				tmp_con.close()
 				fingerprint = hashlib.sha256(certBin).hexdigest().lower()
 			except Exception: pass
+			config = configuration.get_config()
+			if hostport_to_address(self.address) in config['trusted_certs'][hostport_to_address(self.address)]==fingerprint:
+				self.insecure=True
+				return self.run()
 			self.last_fail_fingerprint = fingerprint
 			self.callback_manager.call_callbacks('certificate_authentication_failed')
 			raise

--- a/addon/globalPlugins/remoteClient/transport.py
+++ b/addon/globalPlugins/remoteClient/transport.py
@@ -4,6 +4,7 @@ import queue
 import ssl
 import socket
 import select
+import hashlib
 from collections import defaultdict
 from logging import getLogger
 log = getLogger('transport')
@@ -31,7 +32,7 @@ class TCPTransport(Transport):
 	buffer: bytes
 	closed: bool
 	
-	def __init__(self, serializer, address, timeout=0):
+	def __init__(self, serializer, address, timeout=0, insecure=False):
 		super().__init__(serializer=serializer)
 		self.closed = False
 		#Buffer to hold partially received data
@@ -42,12 +43,25 @@ class TCPTransport(Transport):
 		self.queue_thread = None
 		self.timeout = timeout
 		self.reconnector_thread = ConnectorThread(self)
+		self.insecure=insecure
 
 	def run(self):
 		self.closed = False
 		try:
-			self.server_sock = self.create_outbound_socket(self.address)
+			self.server_sock = self.create_outbound_socket(*self.address, insecure=self.insecure)
 			self.server_sock.connect(self.address)
+		except ssl.SSLCertVerificationError as ex:
+			fingerprint=None
+			try:
+				tmp_con = self.create_outbound_socket(*self.address, insecure = True)
+				tmp_con.connect(self.address)
+				certBin = tmp_con.getpeercert(True)
+				tmp_con.close()
+				fingerprint = hashlib.sha256(certBin).hexdigest().lower()
+			except Exception: pass
+			self.last_fail_fingerprint = fingerprint
+			self.callback_manager.call_callbacks('certificate_authentication_failed')
+			raise
 		except Exception:
 			self.callback_manager.call_callbacks('transport_connection_failed')
 			raise
@@ -74,15 +88,23 @@ class TCPTransport(Transport):
 		self.callback_manager.call_callbacks('transport_disconnected')
 		self._disconnect()
 
-	def create_outbound_socket(self, address):
-		address = socket.getaddrinfo(*address)[0]
+	def create_outbound_socket(self, host, port, insecure=False):
+		address = socket.getaddrinfo(host, port)[0]
 		server_sock = socket.socket(*address[:3])
 		if self.timeout:
 			server_sock.settimeout(self.timeout)
 		server_sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
 		server_sock.ioctl(socket.SIO_KEEPALIVE_VALS, (1, 60000, 2000))
-		server_sock = ssl.wrap_socket(server_sock)
+		ctx = (ssl.SSLContext())
+		if insecure: ctx.verify_mode = ssl.CERT_NONE
+		ctx.check_hostname = not insecure
+		ctx.load_default_certs()
+		server_sock = ctx.wrap_socket(sock=server_sock, server_hostname=host)
 		return server_sock
+
+	def getpeercert(self, binary_form=False):
+		if self.server_sock is None: return None
+		return self.server_sock.getpeercert(binary_form)
 
 	def handle_server_data(self):
 		# This approach may be problematic:
@@ -144,8 +166,8 @@ class TCPTransport(Transport):
 
 class RelayTransport(TCPTransport):
 
-	def __init__(self, serializer, address, timeout=0, channel=None, connection_type=None, protocol_version=PROTOCOL_VERSION):
-		super().__init__(address=address, serializer=serializer, timeout=timeout)
+	def __init__(self, serializer, address, timeout=0, channel=None, connection_type=None, protocol_version=PROTOCOL_VERSION, insecure=False):
+		super().__init__(address=address, serializer=serializer, timeout=timeout, insecure=insecure)
 		log.info("Connecting to %s channel %s" % (address, channel))
 		self.channel = channel
 		self.connection_type = connection_type


### PR DESCRIPTION
This PR addresses a critical, in my opinion, security vulnerability.
Currently the addon does not use SSL certificate hostname and CA chain to verify that user connects to a real server, not to one prepared by a hacker. It may result in Man in the Middle attack and practically excludes all the benefits of using encryption, on the contrary, it can create a very deceptive sense of security.

In this PR i am intending to write the following behavior:
1. If a certificate is a verified certificate, that is providing a correct CA chain and correct host name, it should be accepted,
2. If not, user should be prompted with a warning, also containing a certificate fingerprint and connection should continue when and only when user clearly accepts the risk.
3. Alternatively, user should be allowed to, in advanced settings, manualy provide his own trusted fingerprints for private servers without ability to get proper SSL cert, for example due to lack of a domain (when connecting by IP only or by SSH tunnel).

Currently, I have experimented with points 1 and 2.

I will be very grateful for your feedback.


Closes #234 