### PR TITLE
Fix secure desktop support

### DIFF
--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -469,7 +469,7 @@ class GlobalPlugin(_GlobalPlugin):
 		server_thread = threading.Thread(target=self.sd_server.run)
 		server_thread.daemon = True
 		server_thread.start()
-		self.sd_relay = RelayTransport(address=('127.0.0.1', port), serializer=serializer.JSONSerializer(), channel=channel)
+		self.sd_relay = RelayTransport(address=('127.0.0.1', port), serializer=serializer.JSONSerializer(), channel=channel, insecure=True)
 		self.sd_relay.callback_manager.register_callback('msg_client_joined', self.on_master_display_change)
 		self.slave_transport.callback_manager.register_callback('msg_set_braille_info', self.on_master_display_change)
 		self.sd_bridge = bridge.BridgeTransport(self.slave_transport, self.sd_relay)

--- a/addon/globalPlugins/remoteClient/bridge.py
+++ b/addon/globalPlugins/remoteClient/bridge.py
@@ -1,3 +1,5 @@
+import enum
+
 class BridgeTransport:
 	"""Object to bridge two transports together,
 	passing messages to both of them.
@@ -11,6 +13,8 @@ class BridgeTransport:
 		t2.callback_manager.register_callback('*', self.send_to_t1)
 
 	def send(self, transport, callback, *args, **kwargs):
+		if isinstance(callback, enum.Enum):
+			callback = callback.value
 		if not callback.startswith('msg_'):
 			return
 		msg = callback.split('_', 1)[-1]


### PR DESCRIPTION
This fixes access to the secure desktop, broken by #243.

In the bridge transport, we now check if the callback is an Enum and use its value.
Closes #270.