### PR TITLE
Block the main thread when connecting on the secure desktop so we don't miss the first output.

### DIFF
--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -495,6 +495,7 @@ class GlobalPlugin(_GlobalPlugin):
 	def on_master_display_change(self, **kwargs):
 		self.sd_relay.send(type='set_display_size', sizes=self.slave_session.master_display_sizes)
 
+	SD_CONNECT_BLOCK_TIMEOUT = 1
 	def handle_secure_desktop(self):
 		try:
 			with open(self.ipc_file) as fp:
@@ -506,6 +507,11 @@ class GlobalPlugin(_GlobalPlugin):
 			test_socket.connect(('127.0.0.1', port))
 			test_socket.close()
 			self.connect_as_slave(('127.0.0.1', port), channel, insecure=True)
+			# So we don't miss the first output when switching to a secure desktop,
+			# block the main thread until the connection is established. We're
+			# connecting to localhost, so this should be pretty fast. Use a short
+			# timeout, though.
+			self.slave_transport.connected_event.wait(self.SD_CONNECT_BLOCK_TIMEOUT)
 		except:
 			pass
 

--- a/addon/globalPlugins/remoteClient/transport.py
+++ b/addon/globalPlugins/remoteClient/transport.py
@@ -28,16 +28,19 @@ class Transport:
 	connected: bool
 	successful_connects: int
 	callback_manager: callback_manager.CallbackManager
+	connect_event: threading.Event
 
 	def __init__(self, serializer):
 		self.serializer = serializer
 		self.callback_manager = callback_manager.CallbackManager()
 		self.connected = False
 		self.successful_connects = 0
+		self.connected_event = threading.Event()
 
 	def transport_connected(self):
 		self.successful_connects += 1
 		self.connected = True
+		self.connected_event.set()
 		self.callback_manager.call_callbacks(TransportEvents.CONNECTED)
 
 class TCPTransport(Transport):
@@ -108,6 +111,7 @@ class TCPTransport(Transport):
 					self.buffer = b''
 					break
 		self.connected = False
+		self.connected_event.clear()
 		self.callback_manager.call_callbacks(TransportEvents.DISCONNECTED)
 		self._disconnect()
 


### PR DESCRIPTION
Before this, when switching to a secure desktop, you'd often (always?) miss the first output from NVDA, usually the UAC message.
This could be a little confusing.
This occurred because the connection took a short time to establish, but by then, NVDA had already reported the initial focus.
To get around this, block the main thread until the connection is established.
Since we're connecting to localhost, this should be pretty fast, but we use a 1 second timeout just in case.
This is a bit ugly, but I think it's cleaner and less risky than the alternative of queuing the output until the connection is established.