### PR TITLE
Use shlobj.SHGetKnownFolderPath instead of (now removed) shlobj.SHGetFolderPath.

### DIFF
--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -67,7 +67,7 @@ class GlobalPlugin(_GlobalPlugin):
 		self.sd_relay = None
 		self.sd_bridge = None
 		cs = configuration.get_config()['controlserver']
-		self.temp_location = os.path.join(shlobj.SHGetFolderPath(0, shlobj.CSIDL_COMMON_APPDATA), 'temp')
+		self.temp_location = os.path.join(shlobj.SHGetKnownFolderPath(shlobj.FolderId.PROGRAM_DATA), 'temp')
 		self.ipc_file = os.path.join(self.temp_location, 'remote.ipc')
 		if globalVars.appArgs.secure:
 			self.handle_secure_desktop()


### PR DESCRIPTION
This was removed in nvaccess/nvda#12943, since NVDA 2022.1 is an API breaking release.