### PR TITLE
Automatically remove corrupted configs

### DIFF
--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -44,6 +44,8 @@ from . import bridge
 from .socket_utils import SERVER_PORT, address_to_hostport, hostport_to_address
 import api
 import ssl
+import configobj
+import queueHandler
 
 class GlobalPlugin(_GlobalPlugin):
 	scriptCategory = _("NVDA Remote")
@@ -66,6 +68,11 @@ class GlobalPlugin(_GlobalPlugin):
 		self.sd_server = None
 		self.sd_relay = None
 		self.sd_bridge = None
+		try:
+			configuration.get_config()
+		except configobj.ParseError:
+			os.remove(os.path.abspath(os.path.join(globalVars.appArgs.configPath, configuration.CONFIG_FILE_NAME)))
+			queueHandler.queueFunction(queueHandler.eventQueue, wx.CallAfter, wx.MessageBox, _("Your NVDA Remote configuration was corrupted and has been reset."), _("NVDA Remote Configuration Error"), wx.OK|wx.ICON_EXCLAMATION)
 		cs = configuration.get_config()['controlserver']
 		if hasattr(shlobj, 'SHGetKnownFolderPath'):
 			self.temp_location = os.path.join(shlobj.SHGetKnownFolderPath(shlobj.FolderId.PROGRAM_DATA), 'temp')

--- a/readme.md
+++ b/readme.md
@@ -145,6 +145,7 @@ We would like to acknowledge the following contributors, among others, who helpe
 * Fix the initial focus in the Connect dialog
 * Support pausing of remote speech
 * Replace the host edit box with an edit combo allowing for history
+* Automatically remove corrupted configs
 
 ### Version 2.4
 


### PR DESCRIPTION
When NVDA Remote starts, automatically try to parse the config and remove it if it fails to parse.

If the config fails to parse, nothing works, and you have to manually go in and remove it.
