### PR TITLE
Update GitHub action.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,30 +1,16 @@
-# This is a simple action which builds and releases NVDA Addons
-
 name: CI
-
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
   push:
     branches: [master]
   pull_request:
     branches: [master]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-
-# Set permissions to create a release.
 permissions:
   contents: write
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: windows-latest
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
@@ -33,21 +19,9 @@ jobs:
         run: pip install scons markdown
       - name: Run Scons
         run: scons
-      - name: Create Release
+      - name: Create and Upload Release
         if: contains(github.ref, '/tags/')
-        uses: actions/create-release@latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
           prerelease: ${{ endsWith(github.ref, '-dev') }}
-      - name: Upload release
-        if: contains(github.ref, '/tags/')
-        uses: svenstaro/upload-release-action@2.5.0
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: '*.nvda-addon'
-          tag: ${{ github.ref }}
-          overwrite: true
-          file_glob: true
+          files: '*.nvda-addon'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-# This is a simple action which builds NVDA Addons
+# This is a simple action which builds and releases NVDA Addons
 
 name: CI
 
@@ -13,13 +13,15 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# Set permissions to create a release.
+permissions:
+  contents: write
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
     runs-on: windows-latest
-
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -31,3 +33,21 @@ jobs:
         run: pip install scons markdown
       - name: Run Scons
         run: scons
+      - name: Create Release
+        if: contains(github.ref, '/tags/')
+        uses: actions/create-release@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          prerelease: ${{ endsWith(github.ref, '-dev') }}
+      - name: Upload release
+        if: contains(github.ref, '/tags/')
+        uses: svenstaro/upload-release-action@2.5.0
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: '*.nvda-addon'
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,10 +23,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.10"
       - name: Install Dependencies
         run: pip install scons markdown
       - name: Run Scons


### PR DESCRIPTION
Use version 3 of the checkout action, setup-python version 4, and set up and build with python 3.10.
Allow release creation and upload when a tag is created.