### PR TITLE
Don't create a new keyboard hook thread if there already is one.

### DIFF
--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -338,9 +338,12 @@ class GlobalPlugin(_GlobalPlugin):
 		self.push_clipboard_item.Enable(True)
 		self.copy_link_item.Enable(True)
 		self.send_ctrl_alt_del_item.Enable(True)
-		self.hook_thread = threading.Thread(target=self.hook)
-		self.hook_thread.daemon = True
-		self.hook_thread.start()
+		# We might have already created a hook thread before if we're restoring an
+		# interrupted connection. We must not create another.
+		if not self.hook_thread:
+			self.hook_thread = threading.Thread(target=self.hook)
+			self.hook_thread.daemon = True
+			self.hook_thread.start()
 		self.bindGesture(REMOTE_KEY, "sendKeys")
 		# Translators: Presented when connected to the remote computer.
 		ui.message(_("Connected!"))


### PR DESCRIPTION
When the connection is interrupted, the hook thread isn't terminated. Previously, when the connection was restored, a new hook thread was created without terminating the old one, resulting in abandoned hook threads. Now, we only create a new hook thread when connecting if there isn't a hook thread already.

I discovered this while looking into #290, which I see occasionally. I don't really see how this could cause that. However, when I see #290, it does seem like my keyboard gets trapped sometimes, which made me a bit suspicious of the hook thread. In any case, I think correctness is not a bad thing when messing with hooks. :)