### PR TITLE
Fix freeze when disconnecting after a reconnection due to a socket error.

### DIFF
--- a/addon/globalPlugins/remoteClient/transport.py
+++ b/addon/globalPlugins/remoteClient/transport.py
@@ -192,14 +192,14 @@ class TCPTransport(Transport):
 
 	def _disconnect(self):
 		"""Disconnect the transport due to an error, without closing the connector thread."""
-		if not self.connected:
-			return
 		if self.queue_thread is not None:
 			self.queue.put(None)
 			self.queue_thread.join()
+			self.queue_thread = None
 		clear_queue(self.queue)
-		self.server_sock.close()
-		self.server_sock = None
+		if self.server_sock:
+			self.server_sock.close()
+			self.server_sock = None
 
 	def close(self):
 		self.callback_manager.call_callbacks(TransportEvents.CLOSING)


### PR DESCRIPTION
Previously, if we reconnected because the server disconnected, everything was fine. However, if we reconnected because of a socket error, NVDA often froze when the user eventually tried to disconnect. One way to reproduce this was to turn on airplane mode while using WiFi, wait for disconnection, turn off airplane mode, wait for reconnection, then manually disconnect.

Here's what was happening:

1. When a socket error happened, we broke out of the loop in TCPTransport.run.
2. We set self.disconnected to False and called self._disconnect.
3. self._disconnect checked self.disconnected. Since it was False, it just returned early, doing nothing.
4. That meant that the queue thread was never terminated.
5. Upon reconnection, we created a new queue thread, even though the old one was still running.
6. When the user tried to disconnect, we pushed None into the queue and joined the queue thread.
7. Often, the old queue thread would pick up the queued None and terminate. But we're waiting on the new queue thread! Only one thread gets the queued None.
8. We wait on the new queue thread forever, which never receives None. Infinite freze.

This didn't happen when the server disconnected because when handling no data (EOF) in handle_server_data, we called self._disconnect without setting self.connected to False.

To fix this, don't check self.connected in self._disconnect. Instead, check self.server_sock and don't do the socket stuff if it's None. This way, we always terminate the queue thread (if any) when self._disconnect is called, but we don't barf if the connection isn't up.