### PR TITLE
Remove support for NVDA versions prior to 2024.1

### DIFF
--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -47,11 +47,9 @@ from .socket_utils import SERVER_PORT, address_to_hostport, hostport_to_address
 logging.getLogger("keyboard_hook").addHandler(logging.StreamHandler(sys.stdout))
 import queueHandler
 import shlobj
-import versionInfo
 from logHandler import log
 
-if versionInfo.version_year >= 2024:
-	from winAPI.secureDesktop import post_secureDesktopStateChange
+from winAPI.secureDesktop import post_secureDesktopStateChange
 
 
 class GlobalPlugin(_GlobalPlugin):
@@ -94,8 +92,7 @@ class GlobalPlugin(_GlobalPlugin):
 		if controlServerConfig['autoconnect'] and not self.masterSession and not self.slaveSession:
 			self.performAutoconnect()
 		self.sdFocused = False
-		if versionInfo.version_year >= 2024:
-			post_secureDesktopStateChange.register(self.onSecureDesktopChange)
+		post_secureDesktopStateChange.register(self.onSecureDesktopChange)
 
 	def performAutoconnect(self):
 		controlServerConfig = configuration.get_config()['controlserver']
@@ -144,8 +141,7 @@ class GlobalPlugin(_GlobalPlugin):
 		self.remote_item=tools_menu.AppendSubMenu(self.menu, _("R&emote"), _("NVDA Remote Access"))
 
 	def terminate(self):
-		if versionInfo.version_year >= 2024:
-			post_secureDesktopStateChange.unregister(self.onSecureDesktopChange)
+		post_secureDesktopStateChange.unregister(self.onSecureDesktopChange)
 		self.disconnect()
 		self.localMachine.terminate()
 		self.localMachine = None
@@ -492,18 +488,6 @@ class GlobalPlugin(_GlobalPlugin):
 			self.masterSession.patcher.unpatchBrailleInput()
 			self.localMachine.receivingBraille=False
 
-	if versionInfo.version_year < 2024:
-		def event_gainFocus(self, obj, nextHandler):
-			if isinstance(obj, IAccessibleHandler.SecureDesktopNVDAObject):
-				self.sdFocused = True
-				self.enterSecureDesktop()
-			elif self.sdFocused and not isinstance(obj, IAccessibleHandler.SecureDesktopNVDAObject):
-				#event_leaveFocus won't work for some reason
-				self.sdFocused = False
-				self.leaveSecureDesktop()
-			nextHandler()
-
-	# For NVDA 2024.1 and above
 	def onSecureDesktopChange(self, isSecureDesktop: bool):
 		'''
 		@param isSecureDesktop: True if the new desktop is the secure desktop.

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -487,22 +487,9 @@ class GlobalPlugin(_GlobalPlugin):
 	def setReceivingBraille(self, state):
 		if state and self.masterSession.patchCallbacksAdded and braille.handler.enabled:
 			self.masterSession.patcher.patchBrailleInput()
-			if versionInfo.version_year < 2023:
-				braille.handler.enabled = False
-				if braille.handler._cursorBlinkTimer:
-					braille.handler._cursorBlinkTimer.Stop()
-					braille.handler._cursorBlinkTimer=None
-				if braille.handler.buffer is braille.handler.messageBuffer:
-					braille.handler.buffer.clear()
-					braille.handler.buffer = braille.handler.mainBuffer
-					if braille.handler._messageCallLater:
-						braille.handler._messageCallLater.Stop()
-						braille.handler._messageCallLater = None
 			self.localMachine.receivingBraille=True
 		elif not state:
 			self.masterSession.patcher.unpatchBrailleInput()
-			if versionInfo.version_year < 2023:
-				braille.handler.enabled = bool(braille.handler.displaySize)
 			self.localMachine.receivingBraille=False
 
 	if versionInfo.version_year < 2024:

--- a/addon/globalPlugins/remoteClient/local_machine.py
+++ b/addon/globalPlugins/remoteClient/local_machine.py
@@ -7,7 +7,6 @@ import inputCore
 import nvwave
 import speech
 import tones
-import versionInfo
 import wx
 
 from . import cues, input
@@ -20,7 +19,6 @@ except ModuleNotFoundError:
 import logging
 
 import ui
-import versionInfo
 
 logger = logging.getLogger('local_machine')
 
@@ -31,11 +29,8 @@ def setSpeechCancelledToFalse():
 	speech should not be cancelled. In the long term this is a fragile solution
 	as NVDA does not support modifying the internal state of speech.
 	"""
-	if versionInfo.version_year >= 2021:
-		# workaround as beenCanceled is readonly as of NVDA#12395
-		speech.speech._speechState.beenCanceled = False
-	else:
-		speech.beenCanceled = False
+	# workaround as beenCanceled is readonly as of NVDA#12395
+	speech.speech._speechState.beenCanceled = False
 
 
 class LocalMachine:
@@ -44,12 +39,10 @@ class LocalMachine:
 		self.isMuted = False
 		self.receivingBraille=False
 		self._cachedSizes = None
-		if versionInfo.version_year >= 2023:
-			braille.decide_enabled.register(self.handleDecideEnabled)
+		braille.decide_enabled.register(self.handleDecideEnabled)
 
 	def terminate(self):
-		if versionInfo.version_year >= 2023:
-			braille.decide_enabled.unregister(self.handleDecideEnabled)
+		braille.decide_enabled.unregister(self.handleDecideEnabled)
 
 	def playWave(self, fileName):
 		"""Instructed by remote machine to play a wave file."""
@@ -99,16 +92,7 @@ class LocalMachine:
 			pass
 
 	def setBrailleDisplay_size(self, sizes, **kwargs):
-		if versionInfo.version_year >= 2023:
-			self._cachedSizes = sizes
-			return
-		sizes.append(braille.handler.display.numCells)
-		try:
-			size=min(i for i in sizes if i>0)
-		except ValueError:
-			size = braille.handler.display.numCells
-		braille.handler.displaySize = size
-		braille.handler.enabled = bool(size)
+		self._cachedSizes = sizes
 
 	def handleFilterDisplaySize(self, value):
 		if not self._cachedSizes:

--- a/addon/globalPlugins/remoteClient/session.py
+++ b/addon/globalPlugins/remoteClient/session.py
@@ -13,15 +13,6 @@ from . import configuration, connection_info, cues, local_machine, nvda_patcher
 from .transport import RelayTransport, TransportEvents
 
 addonHandler.initTranslation()
-if not (
-		versionInfo.version_year >= 2021 or
-		(versionInfo.version_year == 2020 and versionInfo.version_major >= 2)
-):
-	# NVDA versions newer than 2020.2 have a _CancellableSpeechCommand which should be ignored by NVDA remote
-	# For older versions, we create a dummy command that won't cause existing commands to be ignored.
-	class _DummyCommand(speech.commands.SpeechCommand):
-		pass
-	speech.commands._CancellableSpeechCommand = _DummyCommand
 
 
 EXCLUDED_SPEECH_COMMANDS = (
@@ -109,9 +100,8 @@ class SlaveSession(RemoteSession):
 			'msg_set_braille_info', self.handleBrailleInfo)
 		self.transport.callback_manager.registerCallback(
 			'msg_set_display_size', self.setDisplaySize)
-		if versionInfo.version_year >= 2023:
-			braille.filter_displaySize.register(
-				self.localMachine.handleFilterDisplaySize)
+		braille.filter_displaySize.register(
+			self.localMachine.handleFilterDisplaySize)
 		self.transport.callback_manager.registerCallback(
 			'msg_braille_input', self.localMachine.brailleInput)
 		self.transport.callback_manager.registerCallback(

--- a/buildVars.py
+++ b/buildVars.py
@@ -29,7 +29,7 @@ addon_info = {
 	# Documentation file name
 	"addon_docFileName" : "readme.html",
 	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
-	"addon_minimumNVDAVersion": "2019.3",
+	"addon_minimumNVDAVersion": "2023.1",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
 	"addon_lastTestedNVDAVersion": "2024.1",
 	# Add-on update channel (default is None, denoting stable releases, and for development releases, use "dev"; do not change unless you know what you are doing)

--- a/buildVars.py
+++ b/buildVars.py
@@ -29,7 +29,7 @@ addon_info = {
 	# Documentation file name
 	"addon_docFileName" : "readme.html",
 	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
-	"addon_minimumNVDAVersion": "2023.1",
+	"addon_minimumNVDAVersion": "2024.1",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
 	"addon_lastTestedNVDAVersion": "2024.1",
 	# Add-on update channel (default is None, denoting stable releases, and for development releases, use "dev"; do not change unless you know what you are doing)


### PR DESCRIPTION
This commit removes legacy code paths that supported NVDA versions before 2023.1,
simplifying the codebase by:

- Removing all version-specific code branches and checks for pre-2023.1 versions
- Using modern NVDA event registration APIs exclusively:
  - braille.decide_enabled
  - braille.displayChanged
  - braille.displaySizeChanged
  - tones.decide_beep
  - nvwave.decide_playWaveFile
  - braille.pre_writeCells
  - inputCore.decide_executeGesture
- Removing deprecated direct handler patching for braille and input
- Updating minimum supported NVDA version to 2023.1 in buildVars.py

This change reduces technical debt and maintenance burden while leveragingNVDA's more robust modern APIs. Users on older NVDA versions should use older versions of NVDA Remote.
