### PR TITLE
Replace string message types with enum

### DIFF
--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -2,6 +2,8 @@ import logging
 
 from typing import Optional, Set, Dict, List, Any, Callable, Union, Type, Tuple
 
+from .protocol import RemoteMessageType
+
 from .secureDesktop import SecureDesktopHandler
 
 from .menu import RemoteMenu
@@ -154,7 +156,7 @@ class GlobalPlugin(_GlobalPlugin):
 	def pushClipboard(self):
 		connector = self.slaveTransport or self.masterTransport
 		try:
-			connector.send(type='set_clipboard_text', text=api.getClipData())
+			connector.send(RemoteMessageType.set_clipboard_text, text=api.getClipData())
 			cues.clipboard_pushed()
 		except TypeError:
 			log.exception("Unable to push clipboard")
@@ -166,7 +168,7 @@ class GlobalPlugin(_GlobalPlugin):
 			ui.message(_("Not connected."))
 			return
 		try:
-			connector.send(type='set_clipboard_text', text=api.getClipData())
+			connector.send(RemoteMessageType.set_clipboard_text, text=api.getClipData())
 			cues.clipboard_pushed()
 			ui.message(_("Clipboard pushed"))
 		except TypeError:
@@ -183,7 +185,7 @@ class GlobalPlugin(_GlobalPlugin):
 		ui.message(_("Copied link"))
 
 	def sendSAS(self):
-		self.masterTransport.send('send_SAS')
+		self.masterTransport.send(RemoteMessageType.send_SAS)
 
 	def disconnect(self):
 		if self.masterTransport is None and self.slaveTransport is None:
@@ -378,7 +380,7 @@ class GlobalPlugin(_GlobalPlugin):
 			if script in self.localScripts:
 				wx.CallAfter(script, gesture)
 				return True
-		self.masterTransport.send(type="key", **kwargs)
+		self.masterTransport.send(RemoteMessageType.key, **kwargs)
 		return True #Don't pass it on
 
 	@script(
@@ -404,7 +406,7 @@ class GlobalPlugin(_GlobalPlugin):
 	def releaseKeys(self):
 		# release all pressed keys in the guest.
 		for k in self.keyModifiers:
-			self.masterTransport.send(type="key", vk_code=k[0], extended=k[1], pressed=False)
+			self.masterTransport.send(RemoteMessageType.key, vk_code=k[0], extended=k[1], pressed=False)
 		self.keyModifiers = set()
 
 	def setReceivingBraille(self, state):

--- a/addon/globalPlugins/remoteClient/protocol.py
+++ b/addon/globalPlugins/remoteClient/protocol.py
@@ -1,0 +1,32 @@
+from enum import Enum
+
+class RemoteMessageType(Enum):
+    # Connection and Protocol Messages
+    protocol_version = "protocol_version"
+    join = "join"
+    channel_joined = "channel_joined"
+    client_joined = "client_joined"
+    client_left = "client_left"
+    
+    # Control Messages
+    key = "key"
+    speak = "speak"
+    cancel = "cancel"
+    pause_speech = "pause_speech"
+    tone = "tone"
+    wave = "wave"
+    send_SAS = "send_SAS"  # Send Secure Attention Sequence
+    
+    # Display and Braille Messages
+    display = "display"
+    braille_input = "braille_input"
+    set_braille_info = "set_braille_info"
+    set_display_size = "set_display_size"
+    
+    # Clipboard Operations
+    set_clipboard_text = "set_clipboard_text"
+    
+    # System Messages
+    ping = "ping"
+    error = "error"
+    

--- a/addon/globalPlugins/remoteClient/protocol.py
+++ b/addon/globalPlugins/remoteClient/protocol.py
@@ -7,6 +7,7 @@ class RemoteMessageType(Enum):
     channel_joined = "channel_joined"
     client_joined = "client_joined"
     client_left = "client_left"
+    generate_key = "generate_key"
     
     # Control Messages
     key = "key"

--- a/addon/globalPlugins/remoteClient/secureDesktop.py
+++ b/addon/globalPlugins/remoteClient/secureDesktop.py
@@ -5,16 +5,19 @@ import ssl
 import threading
 import uuid
 from typing import Optional, Tuple, Any
+
 import shlobj
 
 from pathlib import Path
 from logHandler import log
+from winAPI.secureDesktop import post_secureDesktopStateChange
 
 from . import bridge, server
+from .protocol import RemoteMessageType
 from .transport import RelayTransport
 from .session import SlaveSession
 from .serializer import JSONSerializer
-from winAPI.secureDesktop import post_secureDesktopStateChange
+
 
 def get_program_data_temp_path() -> Path:
 	"""Get the system's program data temp directory path."""
@@ -192,6 +195,6 @@ class SecureDesktopHandler:
 		"""Handle display size changes."""
 		if self.sd_relay is not None and self.slave_session is not None:
 			self.sd_relay.send(
-				type='set_display_size',
+				type=RemoteMessageType.set_display_size,
 				sizes=self.slave_session.masterDisplaySizes
 			)

--- a/addon/globalPlugins/remoteClient/serializer.py
+++ b/addon/globalPlugins/remoteClient/serializer.py
@@ -1,3 +1,5 @@
+from abc import abstractmethod
+from enum import Enum
 from logging import getLogger
 from typing import Any, Dict, List, Optional, Type, Union, TypeVar
 import json
@@ -9,11 +11,24 @@ log = getLogger('serializer')
 T = TypeVar('T')
 JSONDict = Dict[str, Any]
 
+class Serializer:
 
-class JSONSerializer:
+	@abstractmethod
+	def serialize(self, type: Optional[str] = None, **obj: Any) -> bytes:
+		raise NotImplementedError
+	
+	@abstractmethod
+	def deserialize(self, data: bytes) -> JSONDict:
+		raise NotImplementedError
+	
+
+class JSONSerializer(Serializer):
 	SEP: bytes = b'\n'
 
 	def serialize(self, type: Optional[str] = None, **obj: Any) -> bytes:
+		if type is not None:
+			if isinstance(type, Enum):
+				type = type.value
 		obj['type'] = type
 		data = json.dumps(obj, cls=CustomEncoder).encode('UTF-8') + self.SEP
 		return data

--- a/addon/globalPlugins/remoteClient/server.py
+++ b/addon/globalPlugins/remoteClient/server.py
@@ -1,5 +1,8 @@
+from enum import Enum
 import logging
+from .protocol import RemoteMessageType
 from .serializer import JSONSerializer
+
 import os
 import socket
 import ssl
@@ -12,208 +15,209 @@ logger = logging.getLogger(__name__)
 
 
 class LocalRelayServer:
-    PING_TIME: int = 300
-    _running: bool = False
-    port: int
-    password: str
-    clients: Dict[socket.socket, 'Client']
-    clientSockets: List[socket.socket]
-    serverSocket: ssl.SSLSocket
-    serverSocket6: ssl.SSLSocket
-    lastPingTime: float
+	PING_TIME: int = 300
+	_running: bool = False
+	port: int
+	password: str
+	clients: Dict[socket.socket, 'Client']
+	clientSockets: List[socket.socket]
+	serverSocket: ssl.SSLSocket
+	serverSocket6: ssl.SSLSocket
+	lastPingTime: float
 
-    def __init__(self, port: int, password: str, bind_host: str = '', bind_host6: str = '[::]:'):
-        self.port = port
-        self.password = password
-        self.serializer = JSONSerializer()
-        # Maps client sockets to clients
-        self.clients = {}
-        self.clientSockets = []
-        self._running = False
-        self.serverSocket = self.createServerSocket(
-            socket.AF_INET, socket.SOCK_STREAM, bind_addr=(bind_host, self.port))
-        self.serverSocket6 = self.createServerSocket(
-            socket.AF_INET6, socket.SOCK_STREAM, bind_addr=(bind_host6, self.port))
+	def __init__(self, port: int, password: str, bind_host: str = '', bind_host6: str = '[::]:'):
+		self.port = port
+		self.password = password
+		self.serializer = JSONSerializer()
+		# Maps client sockets to clients
+		self.clients = {}
+		self.clientSockets = []
+		self._running = False
+		self.serverSocket = self.createServerSocket(
+			socket.AF_INET, socket.SOCK_STREAM, bind_addr=(bind_host, self.port))
+		self.serverSocket6 = self.createServerSocket(
+			socket.AF_INET6, socket.SOCK_STREAM, bind_addr=(bind_host6, self.port))
 
-    def createServerSocket(self, family: int, type: int, bind_addr: Tuple[str, int]) -> ssl.SSLSocket:
-        serverSocket = socket.socket(family, type)
-        certfile = os.path.join(os.path.abspath(
-            os.path.dirname(__file__)), 'server.pem')
-        serverSocket = ssl.wrap_socket(serverSocket, certfile=certfile)
-        serverSocket.bind(bind_addr)
-        serverSocket.listen(5)
-        return serverSocket
+	def createServerSocket(self, family: int, type: int, bind_addr: Tuple[str, int]) -> ssl.SSLSocket:
+		serverSocket = socket.socket(family, type)
+		certfile = os.path.join(os.path.abspath(
+			os.path.dirname(__file__)), 'server.pem')
+		serverSocket = ssl.wrap_socket(serverSocket, certfile=certfile)
+		serverSocket.bind(bind_addr)
+		serverSocket.listen(5)
+		return serverSocket
 
-    def run(self) -> None:
-        self._running = True
-        self.lastPingTime = time.time()
-        while self._running:
-            r, w, e = select(
-                self.clientSockets+[self.serverSocket, self.serverSocket6], [], self.clientSockets, 60)
-            if not self._running:
-                break
-            for sock in r:
-                if sock is self.serverSocket or sock is self.serverSocket6:
-                    self.acceptNewConnection(sock)
-                    continue
-                self.clients[sock].handleData()
-            if time.time() - self.lastPingTime >= self.PING_TIME:
-                for client in self.clients.values():
-                    if client.authenticated:
-                        client.send(type='ping')
-                self.lastPingTime = time.time()
+	def run(self) -> None:
+		self._running = True
+		self.lastPingTime = time.time()
+		while self._running:
+			r, w, e = select(
+				self.clientSockets+[self.serverSocket, self.serverSocket6], [], self.clientSockets, 60)
+			if not self._running:
+				break
+			for sock in r:
+				if sock is self.serverSocket or sock is self.serverSocket6:
+					self.acceptNewConnection(sock)
+					continue
+				self.clients[sock].handleData()
+			if time.time() - self.lastPingTime >= self.PING_TIME:
+				for client in self.clients.values():
+					if client.authenticated:
+						client.send(type=RemoteMessageType.ping)
+				self.lastPingTime = time.time()
 
-    def acceptNewConnection(self, sock: ssl.SSLSocket) -> None:
-        try:
-            clientSock, addr = sock.accept()
-        except (ssl.SSLError, socket.error, OSError):
-            logger.exception('Error accepting connection')
-            return
-        clientSock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-        client = Client(server=self, socket=clientSock)
-        self.addClient(client)
+	def acceptNewConnection(self, sock: ssl.SSLSocket) -> None:
+		try:
+			clientSock, addr = sock.accept()
+		except (ssl.SSLError, socket.error, OSError):
+			logger.exception('Error accepting connection')
+			return
+		clientSock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+		client = Client(server=self, socket=clientSock)
+		self.addClient(client)
 
-    def addClient(self, client: 'Client') -> None:
-        self.clients[client.socket] = client
-        self.clientSockets.append(client.socket)
+	def addClient(self, client: 'Client') -> None:
+		self.clients[client.socket] = client
+		self.clientSockets.append(client.socket)
 
-    def removeClient(self, client: 'Client') -> None:
-        del self.clients[client.socket]
-        self.clientSockets.remove(client.socket)
+	def removeClient(self, client: 'Client') -> None:
+		del self.clients[client.socket]
+		self.clientSockets.remove(client.socket)
 
-    def clientDisconnected(self, client: 'Client') -> None:
-        self.removeClient(client)
-        if client.authenticated:
-            client.send_to_others(type='client_left',
-                                  user_id=client.id, client=client.asDict())
+	def clientDisconnected(self, client: 'Client') -> None:
+		self.removeClient(client)
+		if client.authenticated:
+			client.send_to_others(type='client_left',
+								  user_id=client.id, client=client.asDict())
 
-    def close(self) -> None:
-        self._running = False
-        self.serverSocket.close()
-        self.serverSocket6.close()
+	def close(self) -> None:
+		self._running = False
+		self.serverSocket.close()
+		self.serverSocket6.close()
 
 
 class Client:
-    id: int = 0
-    server: LocalRelayServer
-    socket: ssl.SSLSocket
-    buffer: bytes
-    authenticated: bool
-    connectionType: Optional[str]
-    protocolVersion: int
+	id: int = 0
+	server: LocalRelayServer
+	socket: ssl.SSLSocket
+	buffer: bytes
+	authenticated: bool
+	connectionType: Optional[str]
+	protocolVersion: int
 
-    def __init__(self, server: LocalRelayServer, socket: ssl.SSLSocket):
-        self.server = server
-        self.socket = socket
-        self.buffer = b''
-        self.serializer = server.serializer
-        self.authenticated = False
-        self.id = Client.id + 1
-        self.connectionType = None
-        self.protocolVersion = 1
-        Client.id += 1
+	def __init__(self, server: LocalRelayServer, socket: ssl.SSLSocket):
+		self.server = server
+		self.socket = socket
+		self.buffer = b''
+		self.serializer = server.serializer
+		self.authenticated = False
+		self.id = Client.id + 1
+		self.connectionType = None
+		self.protocolVersion = 1
+		Client.id += 1
 
-    def handleData(self) -> None:
-        sock_Data: bytes = b''
-        try:
-            # 16384 is 2^14 self.socket is a ssl wrapped socket.
-            # Perhaps this value was chosen as the largest value that could be received [1] to avoid having to loop
-            # until a new line is reached.
-            # However, the Python docs [2] say:
-            # "For best match with hardware and network realities, the value of bufsize should be a relatively
-            # small power of 2, for example, 4096."
-            # This should probably be changed in the future.
-            # See also transport.py handle_server_data in class TCPTransport.
-            # [1] https://stackoverflow.com/a/24870153/
-            # [2] https://docs.python.org/3.7/library/socket.html#socket.socket.recv
-            buffSize = 16384
-            sock_Data = self.socket.recv(buffSize)
-        except:
-            self.close()
-            return
-        if not sock_Data:  # Disconnect
-            self.close()
-            return
-        data = self.buffer + sock_Data
-        if b'\n' not in data:
-            self.buffer = data
-            return
-        self.buffer = b""
-        while b'\n' in data:
-            line, sep, data = data.partition(b'\n')
-            try:
-                self.parse(line)
-            except ValueError:
-                logger.exception('Error parsing line')
-                self.close()
-                return
-        self.buffer += data
+	def handleData(self) -> None:
+		sock_Data: bytes = b''
+		try:
+			# 16384 is 2^14 self.socket is a ssl wrapped socket.
+			# Perhaps this value was chosen as the largest value that could be received [1] to avoid having to loop
+			# until a new line is reached.
+			# However, the Python docs [2] say:
+			# "For best match with hardware and network realities, the value of bufsize should be a relatively
+			# small power of 2, for example, 4096."
+			# This should probably be changed in the future.
+			# See also transport.py handle_server_data in class TCPTransport.
+			# [1] https://stackoverflow.com/a/24870153/
+			# [2] https://docs.python.org/3.7/library/socket.html#socket.socket.recv
+			buffSize = 16384
+			sock_Data = self.socket.recv(buffSize)
+		except:
+			self.close()
+			return
+		if not sock_Data:  # Disconnect
+			self.close()
+			return
+		data = self.buffer + sock_Data
+		if b'\n' not in data:
+			self.buffer = data
+			return
+		self.buffer = b""
+		while b'\n' in data:
+			line, sep, data = data.partition(b'\n')
+			try:
+				self.parse(line)
+			except ValueError:
+				logger.exception('Error parsing line')
+				self.close()
+				return
+		self.buffer += data
 
-    def parse(self, line: bytes) -> None:
-        parsed = self.serializer.deserialize(line)
-        if 'type' not in parsed:
-            return
-        if self.authenticated:
-            self.send_to_others(**parsed)
-            return
-        fn = 'do_'+parsed['type']
-        if hasattr(self, fn):
-            getattr(self, fn)(parsed)
+	def parse(self, line: bytes) -> None:
+		parsed = self.serializer.deserialize(line)
+		if 'type' not in parsed:
+			return
+		if self.authenticated:
+			self.send_to_others(**parsed)
+			return
+		fn = 'do_'+parsed['type']
+		if hasattr(self, fn):
+			getattr(self, fn)(parsed)
 
-    def asDict(self) -> Dict[str, Any]:
-        return dict(id=self.id, connection_type=self.connectionType)
+	def asDict(self) -> Dict[str, Any]:
+		return dict(id=self.id, connection_type=self.connectionType)
 
-    def do_join(self, obj: Dict[str, Any]) -> None:
-        password = obj.get('channel', None)
-        if password != self.server.password:
-            self.send(type='error', message='incorrect_password')
-            self.close()
-            return
-        self.connectionType = obj.get('connection_type')
-        self.authenticated = True
-        clients = []
-        client_ids = []
-        for c in list(self.server.clients.values()):
-            if c is self or not c.authenticated:
-                continue
-            clients.append(c.asDict())
-            client_ids.append(c.id)
-        self.send(type='channel_joined', channel=self.server.password,
-                  user_ids=client_ids, clients=clients)
-        self.send_to_others(type='client_joined',
-                            user_id=self.id, client=self.asDict())
+	def do_join(self, obj: Dict[str, Any]) -> None:
+		password = obj.get('channel', None)
+		if password != self.server.password:
+			self.send(type=RemoteMessageType.error,
+					  message='incorrect_password')
+			self.close()
+			return
+		self.connectionType = obj.get('connection_type')
+		self.authenticated = True
+		clients = []
+		client_ids = []
+		for c in list(self.server.clients.values()):
+			if c is self or not c.authenticated:
+				continue
+			clients.append(c.asDict())
+			client_ids.append(c.id)
+		self.send(type=RemoteMessageType.channel_joined, channel=self.server.password,
+				  user_ids=client_ids, clients=clients)
+		self.send_to_others(type='client_joined',
+							user_id=self.id, client=self.asDict())
 
-    def do_protocol_version(self, obj: Dict[str, Any]) -> None:
-        version = obj.get('version')
-        if not version:
-            return
-        self.protocolVersion = version
+	def do_protocol_version(self, obj: Dict[str, Any]) -> None:
+		version = obj.get('version')
+		if not version:
+			return
+		self.protocolVersion = version
 
-    def close(self) -> None:
-        self.socket.close()
-        self.server.clientDisconnected(self)
+	def close(self) -> None:
+		self.socket.close()
+		self.server.clientDisconnected(self)
 
-    def send(self, type: str, origin: Optional[int] = None,
-             clients: Optional[List[Dict[str, Any]]] = None,
-             client: Optional[Dict[str, Any]] = None,
-             **kwargs: Any) -> None:
-        msg = kwargs
-        if self.protocolVersion > 1:
-            if origin:
-                msg['origin'] = origin
-            if clients:
-                msg['clients'] = clients
-            if client:
-                msg['client'] = client
-        try:
-            data = self.serializer.serialize(type=type, **msg)
-            self.socket.sendall(data)
-        except:
-            self.close()
+	def send(self, type: str|Enum, origin: Optional[int] = None,
+			 clients: Optional[List[Dict[str, Any]]] = None,
+			 client: Optional[Dict[str, Any]] = None,
+			 **kwargs: Any) -> None:
+		msg = kwargs
+		if self.protocolVersion > 1:
+			if origin:
+				msg['origin'] = origin
+			if clients:
+				msg['clients'] = clients
+			if client:
+				msg['client'] = client
+		try:
+			data = self.serializer.serialize(type=type, **msg)
+			self.socket.sendall(data)
+		except:
+			self.close()
 
-    def send_to_others(self, origin: Optional[int] = None, **obj: Any) -> None:
-        if origin is None:
-            origin = self.id
-        for c in self.server.clients.values():
-            if c is not self and c.authenticated:
-                c.send(origin=origin, **obj)
+	def send_to_others(self, origin: Optional[int] = None, **obj: Any) -> None:
+		if origin is None:
+			origin = self.id
+		for c in self.server.clients.values():
+			if c is not self and c.authenticated:
+				c.send(origin=origin, **obj)

--- a/addon/globalPlugins/remoteClient/transport.py
+++ b/addon/globalPlugins/remoteClient/transport.py
@@ -177,7 +177,7 @@ class TCPTransport(Transport):
 			self.parse(line)
 		self.buffer += data
 
-	def parse(self, line):
+	def parse(self, line: bytes) -> None:
 		obj = self.serializer.deserialize(line)
 		if 'type' not in obj:
 			return
@@ -185,7 +185,7 @@ class TCPTransport(Transport):
 		del obj['type']
 		self.callback_manager.callCallbacks(callback, **obj)
 
-	def send_queue(self):
+	def send_queue(self) -> None:
 		while True:
 			item = self.queue.get()
 			if item is None:
@@ -196,7 +196,7 @@ class TCPTransport(Transport):
 			except socket.error:
 				return
 
-	def send(self, type, **kwargs):
+	def send(self, type: str|Enum, **kwargs: Any) -> None:
 		obj = self.serializer.serialize(type=type, **kwargs)
 		if self.connected:
 			self.queue.put(obj)
@@ -241,7 +241,7 @@ class RelayTransport(TCPTransport):
 		self.protocol_version = protocol_version
 		self.callback_manager.registerCallback(TransportEvents.CONNECTED, self.on_connected)
 
-	def on_connected(self):
+	def on_connected(self) -> None:
 		self.send(RemoteMessageType.protocol_version, version=self.protocol_version)
 		if self.channel is not None:
 			self.send(RemoteMessageType.join, channel=self.channel, connection_type=self.connection_type)
@@ -272,7 +272,7 @@ class ConnectorThread(threading.Thread):
 				time.sleep(self.connect_delay)
 		log.info("Ending control connector thread %s" % self.name)
 
-def clear_queue(queue):
+def clear_queue(queue: Queue[Optional[bytes]]) -> None:
 	try:
 		while True:
 			queue.get_nowait()


### PR DESCRIPTION
This pr introduces a typed approach to handling message types in the remote client by:

1. Adding a new RemoteMessageType enum in protocol.py to centralize all message type constants
2. Refactoring message sending code across the codebase to use the enum instead of string literals
3. Updating the JSONSerializer to handle Enum types by extracting their values
4. Adding type hints to support both string and Enum types in relevant functions
5. Creating an abstract Serializer base class to formalize the serialization interface

Key changes:
- Replaced hardcoded strings like 'set_clipboard_text', 'key', 'ping', etc. with enum values
- Updated serializer.py to properly handle Enum types in the type parameter
- Modified message sending code in __init__.py, server.py, session.py, and transport.py
- Added proper type annotations for message type parameters

This change improves type safety and maintainability by:
- Centralizing message type definitions in one place
- Enabling better IDE support and catching typos at compile time
- Making message types more discoverable through the enum
- Establishing a clearer contract for serialization through the abstract base class

The change is backwards compatible with previous versions of Remote.