### PR TITLE
Start work to automatically import configuration to NVDA's config manager.

### DIFF
--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -283,7 +283,6 @@ class GlobalPlugin(_GlobalPlugin):
 		transport.reconnectorThread.start()
 		self.masterTransport = transport
 
-
 	def connectAsSlave(self, address, key, insecure=False):
 		transport = RelayTransport(serializer=serializer.JSONSerializer(), address=address, channel=key, connection_type='slave', insecure=insecure)
 		self.slaveSession = SlaveSession(transport=transport, localMachine=self.localMachine)

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -189,7 +189,7 @@ class GlobalPlugin(_GlobalPlugin):
 	def sendSAS(self):
 		self.masterTransport.send(RemoteMessageType.send_SAS)
 
-	def connect(self, connectionInfo, insecure=False):
+	def connect(self, connectionInfo: ConnectionInfo, insecure=False):
 		if connectionInfo.mode == ConnectionMode.MASTER:
 			self.connectAsMaster((connectionInfo.hostname, connectionInfo.port), connectionInfo.key, insecure)
 		elif connectionInfo.mode == ConnectionMode.SLAVE:

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -402,10 +402,10 @@ class GlobalPlugin(_GlobalPlugin):
 
 	def setReceivingBraille(self, state):
 		if state and self.masterSession.patchCallbacksAdded and braille.handler.enabled:
-			self.masterSession.patcher.patchBrailleInput()
+			self.masterSession.patcher.registerBrailleInput()
 			self.localMachine.receivingBraille=True
 		elif not state:
-			self.masterSession.patcher.unpatchBrailleInput()
+			self.masterSession.patcher.unregisterBrailleInput()
 			self.localMachine.receivingBraille=False
 
 	@alwaysCallAfter

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -293,7 +293,7 @@ class GlobalPlugin(_GlobalPlugin):
 		transport.transportConnectionFailed.register(self.onConnectAsMasterFailed)
 		transport.transportClosing.register(self.disconnectingAsMaster)
 		transport.transportDisconnected.register(self.onDisconnectedAsMaster)
-		transport.reconnector_thread.start()
+		transport.reconnectorThread.start()
 		self.masterTransport = transport
 
 
@@ -304,7 +304,7 @@ class GlobalPlugin(_GlobalPlugin):
 		self.slaveTransport = transport
 		transport.transportCertificateAuthenticationFailed.register(self.onSlaveCertificateFailed)
 		transport.transportConnected.register(self.on_connected_as_slave)
-		transport.reconnector_thread.start()
+		transport.reconnectorThread.start()
 		self.menu.disconnectItem.Enable(True)
 		self.menu.connectItem.Enable(False)
 
@@ -441,4 +441,3 @@ class GlobalPlugin(_GlobalPlugin):
 		if connector is not None:
 			return connector.connected
 		return False
-

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -1,30 +1,10 @@
-import logging
-
-from typing import Optional, Set, Dict, List, Any, Callable, Union, Type, Tuple
-
-
-
-from .alwaysCallAfter import alwaysCallAfter
-from .connection_info import ConnectionInfo, ConnectionMode
-from .menu import RemoteMenu
-from .protocol import SERVER_PORT, RemoteMessageType
-from .secureDesktop import SecureDesktopHandler
-
-# Type aliases
-KeyModifier = Tuple[int, bool]  # (vk_code, extended)
-Address = Tuple[str, int]  # (hostname, port) 
-
-logger = logging.getLogger(__name__)
-
 import ctypes
 import ctypes.wintypes
-import json
+import logging
 import os
-import socket
-import ssl
 import sys
 import threading
-import uuid
+from typing import Callable, Optional, Set, Tuple
 
 import addonHandler
 import api
@@ -32,7 +12,7 @@ import braille
 import configobj
 import globalVars
 import gui
-import IAccessibleHandler
+import queueHandler
 import speech
 import ui
 import wx
@@ -43,9 +23,14 @@ from scriptHandler import script
 from utils.security import isRunningOnSecureDesktop
 
 from . import configuration, cues, local_machine, serializer, url_handler
+from .alwaysCallAfter import alwaysCallAfter
+from .connection_info import ConnectionInfo, ConnectionMode
+from .menu import RemoteMenu
+from .protocol import RemoteMessageType
+from .secureDesktop import SecureDesktopHandler
 from .session import MasterSession, SlaveSession
-from .transport import RelayTransport
 from .settings_panel import RemoteSettingsPanel
+from .transport import RelayTransport
 
 try:
 	addonHandler.initTranslation()
@@ -56,13 +41,18 @@ except addonHandler.AddonError:
 	)
 from winUser import WM_QUIT  # provided by NVDA
 
-from . import bridge, dialogs, keyboard_hook, server
+from . import dialogs, keyboard_hook, server
 from .socket_utils import addressToHostPort, hostPortToAddress
 
 logging.getLogger("keyboard_hook").addHandler(logging.StreamHandler(sys.stdout))
-import queueHandler
-import shlobj
-from logHandler import log
+
+# Type aliases
+KeyModifier = Tuple[int, bool]  # (vk_code, extended)
+Address = Tuple[str, int]  # (hostname, port) 
+
+logger = logging.getLogger(__name__)
+
+
 
 class GlobalPlugin(_GlobalPlugin):
 	scriptCategory: str = _("NVDA Remote")

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -31,11 +31,10 @@ from .secureDesktop import SecureDesktopHandler
 from .session import MasterSession, SlaveSession
 from .settings_panel import RemoteSettingsPanel
 from .transport import RelayTransport
-
+from logHandler import log
 try:
 	addonHandler.initTranslation()
 except addonHandler.AddonError:
-	from logHandler import log
 	log.warning(
 		"Unable to initialise translations. This may be because the addon is running from NVDA scratchpad."
 	)
@@ -49,8 +48,6 @@ logging.getLogger("keyboard_hook").addHandler(logging.StreamHandler(sys.stdout))
 # Type aliases
 KeyModifier = Tuple[int, bool]  # (vk_code, extended)
 Address = Tuple[str, int]  # (hostname, port) 
-
-logger = logging.getLogger(__name__)
 
 
 

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -310,7 +310,7 @@ class GlobalPlugin(_GlobalPlugin):
 			if a == wx.ID_YES:
 				config = configuration.get_config()
 				config['trusted_certs'][hostPortToAddress(self.last_fail_address)]=cert_hash
-				config.write()
+				configuration.save_config()
 			if a == wx.ID_YES or a == wx.ID_NO: return True
 		except Exception as ex:
 			log.error(ex)

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -108,6 +108,7 @@ class GlobalPlugin(_GlobalPlugin):
 			connection = self.sd_handler.initialize_secure_desktop()
 			if connection:
 				self.connectAsSlave(connection.address, connection.channel, insecure=True)
+				self.slaveSession.transport.connected_event.wait(self.sd_handler.SD_CONNECT_BLOCK_TIMEOUT)
 		if controlServerConfig['autoconnect'] and not self.masterSession and not self.slaveSession:
 			self.performAutoconnect()
 

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -220,6 +220,7 @@ class GlobalPlugin(_GlobalPlugin):
 		self.slaveSession = None
 		self.sdHandler.slave_session = None
 
+	@alwaysCallAfter
 	def onConnectAsMasterFailed(self):
 		if self.masterTransport.successfulConnects == 0:
 			self.disconnectAsMaster()
@@ -230,23 +231,24 @@ class GlobalPlugin(_GlobalPlugin):
 
 	@script(gesture="kb:alt+NVDA+pageDown", description=_("""Disconnect a remote session"""))
 	def script_disconnect(self, gesture):
-		if self.masterTransport is None and self.slaveTransport is None:
+		if not self.isConnected:
 			ui.message(_("Not connected."))
 			return
 		self.disconnect()
 
 	@script(gesture="kb:alt+NVDA+pageUp", description=_("""Connect to a remote computer"""))
 	def script_connect(self, gesture):
-		if self.isConnected() or self.connecting: return
+		if self.isConnected() or self.connecting:
+			return
 		self.doConnect(evt = None)
 
 	def doConnect(self, evt=None):
-		if evt is not None: evt.Skip()
+		if evt is not None:
+			evt.Skip()
 		previousConnections = configuration.get_config()['connections']['last_connected']
+		hostnames = list(reversed(previousConnections))
 		# Translators: Title of the connect dialog.
-		dlg = dialogs.DirectConnectDialog(parent=gui.mainFrame, id=wx.ID_ANY, title=_("Connect"))
-		dlg.panel.host.SetItems(list(reversed(previousConnections)))
-		dlg.panel.host.SetSelection(0)
+		dlg = dialogs.DirectConnectDialog(parent=gui.mainFrame, id=wx.ID_ANY, title=_("Connect"), hostnames=hostnames)
 		
 		def handleDialogCompletion(dlg_result):
 			if dlg_result != wx.ID_OK:

--- a/addon/globalPlugins/remoteClient/alwaysCallAfter.py
+++ b/addon/globalPlugins/remoteClient/alwaysCallAfter.py
@@ -1,4 +1,5 @@
 from functools import wraps
+
 import wx
 
 

--- a/addon/globalPlugins/remoteClient/alwaysCallAfter.py
+++ b/addon/globalPlugins/remoteClient/alwaysCallAfter.py
@@ -1,0 +1,10 @@
+from functools import wraps
+import wx
+
+
+def alwaysCallAfter(func):
+	"""Decorator to call a function after the current event loop has finished."""
+	@wraps(func)
+	def wrapper(*args, **kwargs):
+		wx.CallAfter(func, *args, **kwargs)
+	return wrapper

--- a/addon/globalPlugins/remoteClient/beep_sequence.py
+++ b/addon/globalPlugins/remoteClient/beep_sequence.py
@@ -1,7 +1,7 @@
-from typing import Union, Tuple, Sequence
 import collections.abc
 import threading
 import time
+from typing import Tuple, Union
 
 import tones
 
@@ -19,7 +19,7 @@ def beep_sequence(*sequence: BeepElement) -> None:
 		if not isinstance(element, collections.abc.Sequence):
 			time.sleep(float(element) / 1000)
 		else:
-			tone, duration = element  # type: int, int
+			tone, duration = element
 			time.sleep(float(duration) / 1000)
 			local_beep(tone, duration)
 

--- a/addon/globalPlugins/remoteClient/bridge.py
+++ b/addon/globalPlugins/remoteClient/bridge.py
@@ -10,24 +10,24 @@ class BridgeTransport:
 		self.t1 = t1
 		self.t2 = t2
 		# Store callbacks for each message type
-		self.t1_callbacks: Dict[RemoteMessageType, callable] = {}
-		self.t2_callbacks: Dict[RemoteMessageType, callable] = {}
+		self.t1Callbacks: Dict[RemoteMessageType, callable] = {}
+		self.t2Callbacks: Dict[RemoteMessageType, callable] = {}
 		
 		for messageType in RemoteMessageType:
 			# Create and store callbacks
-			self.t1_callbacks[messageType] = self.make_callback(self.t1, messageType)
-			self.t2_callbacks[messageType] = self.make_callback(self.t2, messageType)
+			self.t1Callbacks[messageType] = self.makeCallback(self.t1, messageType)
+			self.t2Callbacks[messageType] = self.makeCallback(self.t2, messageType)
 			# Register with stored references
-			t1.registerInbound(messageType, self.t2_callbacks[messageType])
-			t2.registerInbound(messageType, self.t1_callbacks[messageType])
+			t1.registerInbound(messageType, self.t2Callbacks[messageType])
+			t2.registerInbound(messageType, self.t1Callbacks[messageType])
 
-	def make_callback(self, target_transport: Transport, message_type: RemoteMessageType):
+	def makeCallback(self, targetTransport: Transport, messageType: RemoteMessageType):
 		def callback(*args, **kwargs):
-			if message_type.value not in self.excluded:
-				target_transport.send(message_type, *args, **kwargs)
+			if messageType.value not in self.excluded:
+				targetTransport.send(messageType, *args, **kwargs)
 		return callback
 
 	def disconnect(self):
 		for messageType in RemoteMessageType:
-			self.t1.unregisterInbound(messageType, self.t2_callbacks[messageType])
-			self.t2.unregisterInbound(messageType, self.t1_callbacks[messageType])
+			self.t1.unregisterInbound(messageType, self.t2Callbacks[messageType])
+			self.t2.unregisterInbound(messageType, self.t1Callbacks[messageType])

--- a/addon/globalPlugins/remoteClient/bridge.py
+++ b/addon/globalPlugins/remoteClient/bridge.py
@@ -1,39 +1,33 @@
-from typing import Any, Set, Union
+from typing import Any, Set, Dict
 from enum import Enum
+from .protocol import RemoteMessageType
 from .transport import Transport
 
-
 class BridgeTransport:
-	"""Object to bridge two transports together,
-	passing messages to both of them.
-	We exclude transport-specific messages such as client_joined."""
 	excluded: Set[str] = {'client_joined', 'client_left', 'channel_joined', 'set_braille_info'}
-
-	t1: Transport 
-	t2: Transport
 
 	def __init__(self, t1: Transport, t2: Transport) -> None:
 		self.t1 = t1
 		self.t2 = t2
-		t1.callback_manager.registerCallback('*', self.send_to_t2)
-		t2.callback_manager.registerCallback('*', self.send_to_t1)
+		# Store callbacks for each message type
+		self.t1_callbacks: Dict[RemoteMessageType, callable] = {}
+		self.t2_callbacks: Dict[RemoteMessageType, callable] = {}
+		
+		for messageType in RemoteMessageType:
+			# Create and store callbacks
+			self.t1_callbacks[messageType] = self.make_callback(self.t1, messageType)
+			self.t2_callbacks[messageType] = self.make_callback(self.t2, messageType)
+			# Register with stored references
+			t1.registerInbound(messageType, self.t2_callbacks[messageType])
+			t2.registerInbound(messageType, self.t1_callbacks[messageType])
 
-	def send(self, transport: Transport, callback: Union[str, Enum], *args: Any, **kwargs: Any) -> None:
-		if isinstance(callback, Enum):
-			callback = callback.value
-		if not callback.startswith('msg_'):
-			return
-		msg = callback.split('_', 1)[-1]
-		if msg in self.excluded:
-			return
-		transport.send(msg, *args, **kwargs)
-
-	def send_to_t2(self, callback, *args, **kwargs):
-		self.send(self.t2, callback, *args, **kwargs)
-
-	def send_to_t1(self, callback, *args, **kwargs):
-		self.send(self.t1, callback, *args, **kwargs)
+	def make_callback(self, target_transport: Transport, message_type: RemoteMessageType):
+		def callback(*args, **kwargs):
+			if message_type.value not in self.excluded:
+				target_transport.send(message_type, *args, **kwargs)
+		return callback
 
 	def disconnect(self):
-		self.t1.callback_manager.unregisterCallback('*', self.send_to_t2)
-		self.t2.callback_manager.unregisterCallback('*', self.send_to_t1)
+		for messageType in RemoteMessageType:
+			self.t1.unregisterInbound(messageType, self.t2_callbacks[messageType])
+			self.t2.unregisterInbound(messageType, self.t1_callbacks[messageType])

--- a/addon/globalPlugins/remoteClient/configuration.py
+++ b/addon/globalPlugins/remoteClient/configuration.py
@@ -43,8 +43,8 @@ def get_config():
 			val = validate.Validator()
 			_config.validate(val, copy=True)
 			# Save the config spec to NVDA's config
-			nvdaConf.spec[configRoot] = _config.configspec.copy()
-			nvdaConf[configRoot] = _config.copy()
+			nvdaConf.spec[configRoot] = _config.configspec.dict()
+			nvdaConf[configRoot] = _config.dict()
 			save_config()
 			# os.remove(path)
 	_config = nvdaConf[configRoot]

--- a/addon/globalPlugins/remoteClient/configuration.py
+++ b/addon/globalPlugins/remoteClient/configuration.py
@@ -13,6 +13,29 @@ nvdaConf.BASE_ONLY_SECTIONS.add(configRoot)
 CONFIG_FILE_NAME = 'remote.ini'
 
 _config = None
+configspec2 = {
+	'connections': {
+		'last_connected': 'list(default=list())'
+	}, 
+	'controlserver': {
+		'autoconnect': 'boolean(default=False)',
+		'self_hosted': 'boolean(default=False)',
+		'connection_type': 'integer(default=0)', 
+		'host': 'string(default="")', 
+		'port': 'integer(default=6837)', 
+		'key': 'string(default="")'
+	},
+	'seen_motds': {
+		'__many__': 'string(default="")'
+	}, 
+	'trusted_certs': {
+		'__many__': 'string(default="")'
+	}, 
+	'ui': {
+		'play_sounds': 'boolean(default=True)'
+	}
+}
+
 configspec = StringIO("""
 [connections]
 	last_connected = list(default=list())
@@ -34,19 +57,20 @@ configspec = StringIO("""
 	play_sounds = boolean(default=True)
 """)
 
+
 def get_config():
 	global _config
 	if not _config:
+		# Save the config spec to NVDA's config
+		nvdaConf.spec[configRoot] = configspec2
 		path = os.path.abspath(os.path.join(globalVars.appArgs.configPath, CONFIG_FILE_NAME))
 		if os.path.exists(path):
 			_config = configobj.ConfigObj(infile=path, configspec=configspec, create_empty=True)
 			val = validate.Validator()
 			_config.validate(val, copy=True)
-			# Save the config spec to NVDA's config
-			nvdaConf.spec[configRoot] = _config.configspec.dict()
 			nvdaConf[configRoot] = _config.dict()
-			save_config()
-			# os.remove(path)
+			os.remove(path)
+		save_config()
 	_config = nvdaConf[configRoot]
 	return _config
 

--- a/addon/globalPlugins/remoteClient/configuration.py
+++ b/addon/globalPlugins/remoteClient/configuration.py
@@ -59,7 +59,7 @@ def write_connection_to_config(address):
 	If the address is already in the config, move it to the end."""
 	conf = get_config()
 	last_cons = conf['connections']['last_connected']
-	address = socket_utils.hostport_to_address(address)
+	address = socket_utils.hostPortToAddress(address)
 	if address in last_cons:
 		conf['connections']['last_connected'].remove(address)
 	conf['connections']['last_connected'].append(address)

--- a/addon/globalPlugins/remoteClient/connection_info.py
+++ b/addon/globalPlugins/remoteClient/connection_info.py
@@ -48,7 +48,7 @@ class ConnectionInfo:
 		
 		# Use urlunparse for proper URL construction
 		return urlparse.urlunparse((
-			'nvdaremote',  # scheme from URL_PREFIX
+			URL_PREFIX.split('://')[0],  # scheme from URL_PREFIX
 			netloc,        # network location
 			'',           # path
 			'',           # params

--- a/addon/globalPlugins/remoteClient/connection_info.py
+++ b/addon/globalPlugins/remoteClient/connection_info.py
@@ -1,20 +1,21 @@
+from dataclasses import dataclass
 from urllib.parse import parse_qs, urlencode, urlparse
 
-
 from .protocol import SERVER_PORT, URL_PREFIX
-
 from . import socket_utils
 
 class URLParsingError(Exception):
 	"""Raised if it's impossible to parse out the URL"""
 
+@dataclass
 class ConnectionInfo:
+	hostname: str
+	mode: str
+	key: str
+	port: int = SERVER_PORT
 
-	def __init__(self, hostname, mode, key, port=SERVER_PORT):
-		self.hostname = hostname
-		self.mode = mode
-		self.key = key
-		self.port = port or SERVER_PORT
+	def __post_init__(self):
+		self.port = self.port or SERVER_PORT
 
 	@classmethod
 	def fromURL(cls, url):
@@ -34,8 +35,6 @@ class ConnectionInfo:
 			raise URLParsingError("Invalud mode provided: %r" % mode)
 		return cls(hostname=hostname, mode=mode, key=key, port=port)
 
-	def __repr__(self):
-		return "{classname} (hostname={hostname}, port={port}, mode={mode}, key={key})".format(classname=self.__class__.__name__, hostname=self.hostname, port=self.port, mode=self.mode, key=self.key)
 
 	def getAddress(self):
 		hostname = (self.hostname if ':' not in self.hostname else '[' + self.hostname + ']')

--- a/addon/globalPlugins/remoteClient/connection_info.py
+++ b/addon/globalPlugins/remoteClient/connection_info.py
@@ -45,8 +45,10 @@ class ConnectionInfo:
 			raise URLParsingError("No key provided")
 		if not mode:
 			raise URLParsingError("No mode provided")
-		if mode not in ('master', 'slave'):
-			raise URLParsingError("Invalud mode provided: %r" % mode)
+		try:
+			ConnectionMode(mode)
+		except ValueError:
+			raise URLParsingError("Invalid mode provided: %r" % mode)
 		return cls(hostname=hostname, mode=mode, key=key, port=port)
 
 
@@ -58,7 +60,7 @@ class ConnectionInfo:
 	def _build_url(self, mode: ConnectionMode):
 		# Build URL components
 		netloc = socket_utils.hostPortToAddress((self.hostname, self.port))
-		query = urlencode({'key': self.key, 'mode': mode})
+		query = urlencode({'key': self.key, 'mode': mode if isinstance(mode, str) else mode.value})
 		
 		# Use urlunparse for proper URL construction
 		return urlparse.urlunparse((
@@ -72,8 +74,8 @@ class ConnectionInfo:
 
 	def getURLToConnect(self):
 		# Flip master/slave for connection URL
-		connect_mode = 'slave' if self.mode == 'master' else 'master'
-		return self._build_url(connect_mode)
+		connect_mode = ConnectionMode.SLAVE if self.mode == ConnectionMode.MASTER else ConnectionMode.MASTER
+		return self._build_url(connect_mode.value)
 
 	def getURL(self):
 		return self._build_url(self.mode)

--- a/addon/globalPlugins/remoteClient/connection_info.py
+++ b/addon/globalPlugins/remoteClient/connection_info.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 from .protocol import SERVER_PORT, URL_PREFIX
 from . import socket_utils
@@ -63,7 +63,7 @@ class ConnectionInfo:
 		query = urlencode({'key': self.key, 'mode': mode if isinstance(mode, str) else mode.value})
 		
 		# Use urlunparse for proper URL construction
-		return urlparse.urlunparse((
+		return urlunparse((
 			URL_PREFIX.split('://')[0],  # scheme from URL_PREFIX
 			netloc,        # network location
 			'',           # path

--- a/addon/globalPlugins/remoteClient/connection_info.py
+++ b/addon/globalPlugins/remoteClient/connection_info.py
@@ -2,8 +2,9 @@ from dataclasses import dataclass
 from enum import Enum
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
-from .protocol import SERVER_PORT, URL_PREFIX
 from . import socket_utils
+from .protocol import SERVER_PORT, URL_PREFIX
+
 
 class URLParsingError(Exception):
 	"""Raised if it's impossible to parse out the URL"""

--- a/addon/globalPlugins/remoteClient/connection_info.py
+++ b/addon/globalPlugins/remoteClient/connection_info.py
@@ -1,28 +1,29 @@
 from urllib.parse import parse_qs, urlencode, urlparse
 
-from . import socket_utils
 
-URL_PREFIX = 'nvdaremote://'
+from .protocol import SERVER_PORT, URL_PREFIX
+
+from . import socket_utils
 
 class URLParsingError(Exception):
 	"""Raised if it's impossible to parse out the URL"""
 
 class ConnectionInfo:
 
-	def __init__(self, hostname, mode, key, port=socket_utils.SERVER_PORT):
+	def __init__(self, hostname, mode, key, port=SERVER_PORT):
 		self.hostname = hostname
 		self.mode = mode
 		self.key = key
-		self.port = port or socket_utils.SERVER_PORT
+		self.port = port or SERVER_PORT
 
 	@classmethod
-	def from_url(cls, url):
-		parsed_url = urlparse(url)
-		parsed_query = parse_qs(parsed_url.query)
-		hostname = parsed_url.hostname
-		port = parsed_url.port
-		key = parsed_query.get('key', [""])[0]
-		mode = parsed_query.get('mode', [""])[0].lower()
+	def fromURL(cls, url):
+		parsedUrl = urlparse(url)
+		parsedQuery = parse_qs(parsedUrl.query)
+		hostname = parsedUrl.hostname
+		port = parsedUrl.port
+		key = parsedQuery.get('key', [""])[0]
+		mode = parsedQuery.get('mode', [""])[0].lower()
 		if not hostname:
 			raise URLParsingError("No hostname provided")
 		if not key:
@@ -36,12 +37,12 @@ class ConnectionInfo:
 	def __repr__(self):
 		return "{classname} (hostname={hostname}, port={port}, mode={mode}, key={key})".format(classname=self.__class__.__name__, hostname=self.hostname, port=self.port, mode=self.mode, key=self.key)
 
-	def get_address(self):
+	def getAddress(self):
 		hostname = (self.hostname if ':' not in self.hostname else '[' + self.hostname + ']')
 		return '{hostname}:{port}'.format(hostname=hostname, port=self.port)
 
-	def get_url_to_connect(self):
-		result = URL_PREFIX + socket_utils.hostport_to_address((self.hostname, self.port))
+	def getURLToConnect(self):
+		result = URL_PREFIX + socket_utils.hostPortToAddress((self.hostname, self.port))
 		result += '?'
 		mode = self.mode
 		if mode == 'master':
@@ -51,8 +52,8 @@ class ConnectionInfo:
 		result += urlencode(dict(key=self.key, mode=mode))
 		return result
 
-	def get_url(self):
-		result = URL_PREFIX + socket_utils.hostport_to_address((self.hostname, self.port))
+	def getURL(self):
+		result = URL_PREFIX + socket_utils.hostPortToAddress((self.hostname, self.port))
 		result += '?'
 		mode = self.mode
 		result += urlencode(dict(key=self.key, mode=mode))

--- a/addon/globalPlugins/remoteClient/dialogs.py
+++ b/addon/globalPlugins/remoteClient/dialogs.py
@@ -1,7 +1,7 @@
 import json
 import random
 import threading
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 from urllib import request
 
 import addonHandler
@@ -170,7 +170,7 @@ class DirectConnectDialog(wx.Dialog):
 	panel: Union[ClientPanel, ServerPanel]
 	main_sizer: wx.BoxSizer
 
-	def __init__(self, parent: wx.Window, id: int, title: str):
+	def __init__(self, parent: wx.Window, id: int, title: str, hostnames: Optional[List[str]] = None):
 		super().__init__(parent, id, title=title)
 		main_sizer = self.main_sizer = wx.BoxSizer(wx.VERTICAL)
 		self.client_or_server = wx.RadioBox(self, wx.ID_ANY, choices=(_("Client"), _("Server")), style=wx.RA_VERTICAL)
@@ -192,6 +192,9 @@ class DirectConnectDialog(wx.Dialog):
 		ok = wx.FindWindowById(wx.ID_OK, self)
 		ok.Bind(wx.EVT_BUTTON, self.onOk)
 		self.client_or_server.SetFocus()
+		if hostnames:
+			self.panel.host.AppendItems(hostnames)
+			self.panel.host.SetSelection(0)
 
 	def onClientOrServer(self, evt: wx.CommandEvent) -> None:
 		evt.Skip()

--- a/addon/globalPlugins/remoteClient/dialogs.py
+++ b/addon/globalPlugins/remoteClient/dialogs.py
@@ -80,7 +80,7 @@ class ClientPanel(wx.Panel):
 			if a == wx.ID_YES:
 				config = configuration.get_config()
 				config['trusted_certs'][self.host.GetValue()]=cert_hash
-				config.write()
+				configuration.save_config()
 			if a != wx.ID_YES and a != wx.ID_NO: return
 		except Exception as ex:
 			log.error(ex)

--- a/addon/globalPlugins/remoteClient/dialogs.py
+++ b/addon/globalPlugins/remoteClient/dialogs.py
@@ -11,6 +11,7 @@ from logHandler import log
 
 from . import configuration, serializer, server, socket_utils, transport
 from .alwaysCallAfter import alwaysCallAfter
+from .connection_info import ConnectionInfo
 from .protocol import RemoteMessageType, SERVER_PORT
 
 try:
@@ -213,7 +214,28 @@ class DirectConnectDialog(wx.Dialog):
 
 	def getKey(self) -> str:
 		return self.panel.key.GetValue()
-
+	
+	def getConnectionInfo(self) -> ConnectionInfo:
+		if self.client_or_server.GetSelection() == 0:  # client
+			host = self.panel.host.GetValue()
+			serverAddr, port = socket_utils.addressToHostPort(host)
+			mode = 'master' if self.connection_type.GetSelection() == 0 else 'slave'
+			return ConnectionInfo(
+				hostname=serverAddr, 
+				mode=mode, 
+				key=self.getKey(), 
+				port=port
+			)
+		else:  # server
+			port = int(self.panel.port.GetValue())
+			mode = 'master' if self.connection_type.GetSelection() == 0 else 'slave'
+			return ConnectionInfo(
+				hostname='127.0.0.1',
+				mode=mode,
+				key=self.getKey(),
+				port=port
+			)
+	
 class CertificateUnauthorizedDialog(wx.MessageDialog):
 	def __init__(self, parent: Optional[wx.Window], fingerprint: Optional[str] = None):
 		# Translators: A title bar of a window presented when an attempt has been made to connect with a server with unauthorized certificate.

--- a/addon/globalPlugins/remoteClient/dialogs.py
+++ b/addon/globalPlugins/remoteClient/dialogs.py
@@ -1,7 +1,7 @@
 import json
 import random
 import threading
-from typing import Any, Dict, Optional, Union, cast
+from typing import Any, Dict, Optional, Union
 from urllib import request
 
 import addonHandler
@@ -12,7 +12,7 @@ from logHandler import log
 from . import configuration, serializer, server, socket_utils, transport
 from .alwaysCallAfter import alwaysCallAfter
 from .connection_info import ConnectionInfo, ConnectionMode
-from .protocol import RemoteMessageType, SERVER_PORT
+from .protocol import SERVER_PORT, RemoteMessageType
 
 try:
 	addonHandler.initTranslation()

--- a/addon/globalPlugins/remoteClient/dialogs.py
+++ b/addon/globalPlugins/remoteClient/dialogs.py
@@ -11,7 +11,7 @@ from logHandler import log
 
 from . import configuration, serializer, server, socket_utils, transport
 from .alwaysCallAfter import alwaysCallAfter
-from .connection_info import ConnectionInfo
+from .connection_info import ConnectionInfo, ConnectionMode
 from .protocol import RemoteMessageType, SERVER_PORT
 
 try:
@@ -219,7 +219,7 @@ class DirectConnectDialog(wx.Dialog):
 		if self.client_or_server.GetSelection() == 0:  # client
 			host = self.panel.host.GetValue()
 			serverAddr, port = socket_utils.addressToHostPort(host)
-			mode = 'master' if self.connection_type.GetSelection() == 0 else 'slave'
+			mode = ConnectionMode.MASTER if self.connection_type.GetSelection() == 0 else ConnectionMode.SLAVE
 			return ConnectionInfo(
 				hostname=serverAddr, 
 				mode=mode, 
@@ -235,7 +235,7 @@ class DirectConnectDialog(wx.Dialog):
 				key=self.getKey(),
 				port=port
 			)
-	
+
 class CertificateUnauthorizedDialog(wx.MessageDialog):
 	def __init__(self, parent: Optional[wx.Window], fingerprint: Optional[str] = None):
 		# Translators: A title bar of a window presented when an attempt has been made to connect with a server with unauthorized certificate.

--- a/addon/globalPlugins/remoteClient/input.py
+++ b/addon/globalPlugins/remoteClient/input.py
@@ -6,7 +6,6 @@ import baseObject
 import braille
 import brailleInput
 import globalPluginHandler
-import inputCore
 import scriptHandler
 import vision
 

--- a/addon/globalPlugins/remoteClient/local_machine.py
+++ b/addon/globalPlugins/remoteClient/local_machine.py
@@ -1,7 +1,7 @@
-from typing import List, Optional, Union, Sequence, Any, Dict
 import ctypes
-import os
 import logging
+import os
+from typing import Any, Dict, List, Optional 
 
 import api
 import braille
@@ -10,8 +10,8 @@ import nvwave
 import speech
 import tones
 import wx
-from speech.types import SpeechSequence
 from speech.priorities import Spri
+from speech.types import SpeechSequence
 
 from . import cues, input
 
@@ -20,7 +20,6 @@ try:
 except ModuleNotFoundError:
     from config import hasUiAccess
 
-import logging
 
 import ui
 

--- a/addon/globalPlugins/remoteClient/menu.py
+++ b/addon/globalPlugins/remoteClient/menu.py
@@ -96,6 +96,8 @@ class RemoteMenu(wx.Menu):
 		self.connectItem.Enable(not connected)
 		self.disconnectItem.Enable(connected)
 		self.muteItem.Enable(connected)
+		if not connected:
+			self.muteItem.Check(False)
 		self.pushClipboardItem.Enable(connected)
 		self.copyLinkItem.Enable(connected)
 		self.sendCtrlAltDelItem.Enable(connected)

--- a/addon/globalPlugins/remoteClient/menu.py
+++ b/addon/globalPlugins/remoteClient/menu.py
@@ -1,103 +1,136 @@
-from typing import Optional, Callable
 import wx
 
 import gui
 
+
 class RemoteMenu(wx.Menu):
-	"""Menu for the NVDA Remote addon that appears in the NVDA Tools menu"""
-	
-	connectItem: wx.MenuItem
-	disconnectItem: wx.MenuItem 
-	muteItem: wx.MenuItem
-	pushClipboardItem: wx.MenuItem
-	copyLinkItem: wx.MenuItem
-	sendCtrlAltDelItem: wx.MenuItem
-	remoteItem: wx.MenuItem
+    """Menu for the NVDA Remote addon that appears in the NVDA Tools menu"""
 
-	def __init__(self, client) -> None:
-		super().__init__()
-		self.client = client
-		toolsMenu = gui.mainFrame.sysTrayIcon.toolsMenu
-		# Translators: Item in NVDA Remote submenu to connect to a remote computer.
-		self.connectItem: wx.MenuItem = self.Append(wx.ID_ANY, _("Connect..."), _("Remotely connect to another computer running NVDA Remote Access"))
-		gui.mainFrame.sysTrayIcon.Bind(wx.EVT_MENU, self.client.doConnect, self.connectItem)
-		# Translators: Item in NVDA Remote submenu to disconnect from a remote computer.
-		self.disconnectItem: wx.MenuItem = self.Append(wx.ID_ANY, _("Disconnect"), _("Disconnect from another computer running NVDA Remote Access"))
-		self.disconnectItem.Enable(False)
-		gui.mainFrame.sysTrayIcon.Bind(wx.EVT_MENU, self.onDisconnectItem, self.disconnectItem)
-		# Translators: Menu item in NvDA Remote submenu to mute speech and sounds from the remote computer.
-		self.muteItem: wx.MenuItem = self.Append(wx.ID_ANY, _("Mute remote"), _("Mute speech and sounds from the remote computer"), kind=wx.ITEM_CHECK)
-		self.muteItem.Enable(False)
-		gui.mainFrame.sysTrayIcon.Bind(wx.EVT_MENU, self.onMuteItem, self.muteItem)
-		# Translators: Menu item in NVDA Remote submenu to push clipboard content to the remote computer.
-		self.pushClipboardItem: wx.MenuItem = self.Append(wx.ID_ANY, _("&Push clipboard"), _("Push the clipboard to the other machine"))
-		self.pushClipboardItem.Enable(False)
-		gui.mainFrame.sysTrayIcon.Bind(wx.EVT_MENU, self.onPushClipboardItem, self.pushClipboardItem)
-		# Translators: Menu item in NVDA Remote submenu to copy a link to the current session.
-		self.copyLinkItem: wx.MenuItem = self.Append(wx.ID_ANY, _("Copy &link"), _("Copy a link to the remote session"))
-		self.copyLinkItem.Enable(False)
-		gui.mainFrame.sysTrayIcon.Bind(wx.EVT_MENU, self.onCopyLinkItem, self.copyLinkItem)
-		# Translators: Menu item in NVDA Remote submenu to send Control+Alt+Delete to the remote computer.
-		self.sendCtrlAltDelItem: wx.MenuItem = self.Append(wx.ID_ANY, _("Send Ctrl+Alt+Del"), _("Send Ctrl+Alt+Del"))
-		gui.mainFrame.sysTrayIcon.Bind(wx.EVT_MENU, self.onSendCtrlAltDel, self.sendCtrlAltDelItem)
-		self.sendCtrlAltDelItem.Enable(False)
-		# Translators: Label of menu in NVDA tools menu.
-		self.remoteItem=toolsMenu.AppendSubMenu(self, _("R&emote"), _("NVDA Remote Access"))
+    connectItem: wx.MenuItem
+    disconnectItem: wx.MenuItem
+    muteItem: wx.MenuItem
+    pushClipboardItem: wx.MenuItem
+    copyLinkItem: wx.MenuItem
+    sendCtrlAltDelItem: wx.MenuItem
+    remoteItem: wx.MenuItem
 
-	def terminate(self) -> None:
-		self.Remove(self.connectItem.Id)
-		self.connectItem.Destroy()
-		self.connectItem=None
-		self.Remove(self.disconnectItem.Id)
-		self.disconnectItem.Destroy()
-		self.disconnectItem=None
-		self.Remove(self.muteItem.Id)
-		self.muteItem.Destroy()
-		self.muteItem=None
-		self.Remove(self.pushClipboardItem.Id)
-		self.pushClipboardItem.Destroy()
-		self.pushClipboardItem=None
-		self.Remove(self.copyLinkItem.Id)
-		self.copyLinkItem.Destroy()
-		self.copyLinkItem = None
-		self.Remove(self.sendCtrlAltDelItem.Id)
-		self.sendCtrlAltDelItem.Destroy()
-		self.sendCtrlAltDelItem=None
-		tools_menu = gui.mainFrame.sysTrayIcon.toolsMenu
-		tools_menu.Remove(self.remoteItem.Id)
-		self.remoteItem.Destroy()
-		self.remoteItem=None
-		try:
-			self.Destroy()
-		except (RuntimeError, AttributeError):
-			pass
+    def __init__(self, client) -> None:
+        super().__init__()
+        self.client = client
+        toolsMenu = gui.mainFrame.sysTrayIcon.toolsMenu
+        # Translators: Item in NVDA Remote submenu to connect to a remote computer.
+        self.connectItem: wx.MenuItem = self.Append(
+            wx.ID_ANY,
+            _("Connect..."),
+            _("Remotely connect to another computer running NVDA Remote Access"),
+        )
+        gui.mainFrame.sysTrayIcon.Bind(
+            wx.EVT_MENU, self.client.doConnect, self.connectItem
+        )
+        # Translators: Item in NVDA Remote submenu to disconnect from a remote computer.
+        self.disconnectItem: wx.MenuItem = self.Append(
+            wx.ID_ANY,
+            _("Disconnect"),
+            _("Disconnect from another computer running NVDA Remote Access"),
+        )
+        self.disconnectItem.Enable(False)
+        gui.mainFrame.sysTrayIcon.Bind(
+            wx.EVT_MENU, self.onDisconnectItem, self.disconnectItem
+        )
+        # Translators: Menu item in NvDA Remote submenu to mute speech and sounds from the remote computer.
+        self.muteItem: wx.MenuItem = self.Append(
+            wx.ID_ANY,
+            _("Mute remote"),
+            _("Mute speech and sounds from the remote computer"),
+            kind=wx.ITEM_CHECK,
+        )
+        self.muteItem.Enable(False)
+        gui.mainFrame.sysTrayIcon.Bind(wx.EVT_MENU, self.onMuteItem, self.muteItem)
+        # Translators: Menu item in NVDA Remote submenu to push clipboard content to the remote computer.
+        self.pushClipboardItem: wx.MenuItem = self.Append(
+            wx.ID_ANY,
+            _("&Push clipboard"),
+            _("Push the clipboard to the other machine"),
+        )
+        self.pushClipboardItem.Enable(False)
+        gui.mainFrame.sysTrayIcon.Bind(
+            wx.EVT_MENU, self.onPushClipboardItem, self.pushClipboardItem
+        )
+        # Translators: Menu item in NVDA Remote submenu to copy a link to the current session.
+        self.copyLinkItem: wx.MenuItem = self.Append(
+            wx.ID_ANY, _("Copy &link"), _("Copy a link to the remote session")
+        )
+        self.copyLinkItem.Enable(False)
+        gui.mainFrame.sysTrayIcon.Bind(
+            wx.EVT_MENU, self.onCopyLinkItem, self.copyLinkItem
+        )
+        # Translators: Menu item in NVDA Remote submenu to send Control+Alt+Delete to the remote computer.
+        self.sendCtrlAltDelItem: wx.MenuItem = self.Append(
+            wx.ID_ANY, _("Send Ctrl+Alt+Del"), _("Send Ctrl+Alt+Del")
+        )
+        gui.mainFrame.sysTrayIcon.Bind(
+            wx.EVT_MENU, self.onSendCtrlAltDel, self.sendCtrlAltDelItem
+        )
+        self.sendCtrlAltDelItem.Enable(False)
+        # Translators: Label of menu in NVDA tools menu.
+        self.remoteItem = toolsMenu.AppendSubMenu(
+            self, _("R&emote"), _("NVDA Remote Access")
+        )
 
-	def onDisconnectItem(self, evt: wx.CommandEvent) -> None:
-		evt.Skip()
-		self.client.disconnect()
+    def terminate(self) -> None:
+        self.Remove(self.connectItem.Id)
+        self.connectItem.Destroy()
+        self.connectItem = None
+        self.Remove(self.disconnectItem.Id)
+        self.disconnectItem.Destroy()
+        self.disconnectItem = None
+        self.Remove(self.muteItem.Id)
+        self.muteItem.Destroy()
+        self.muteItem = None
+        self.Remove(self.pushClipboardItem.Id)
+        self.pushClipboardItem.Destroy()
+        self.pushClipboardItem = None
+        self.Remove(self.copyLinkItem.Id)
+        self.copyLinkItem.Destroy()
+        self.copyLinkItem = None
+        self.Remove(self.sendCtrlAltDelItem.Id)
+        self.sendCtrlAltDelItem.Destroy()
+        self.sendCtrlAltDelItem = None
+        tools_menu = gui.mainFrame.sysTrayIcon.toolsMenu
+        tools_menu.Remove(self.remoteItem.Id)
+        self.remoteItem.Destroy()
+        self.remoteItem = None
+        try:
+            self.Destroy()
+        except (RuntimeError, AttributeError):
+            pass
 
-	def onMuteItem(self, evt: wx.CommandEvent) -> None:
-		evt.Skip()
-		self.client.toggleMute()
+    def onDisconnectItem(self, evt: wx.CommandEvent) -> None:
+        evt.Skip()
+        self.client.disconnect()
 
-	def onPushClipboardItem(self, evt: wx.CommandEvent) -> None:
-		evt.Skip()
-		self.client.pushClipboard()
+    def onMuteItem(self, evt: wx.CommandEvent) -> None:
+        evt.Skip()
+        self.client.toggleMute()
 
-	def onCopyLinkItem(self, evt: wx.CommandEvent) -> None:
-		evt.Skip()
-		self.client.copyLink()
+    def onPushClipboardItem(self, evt: wx.CommandEvent) -> None:
+        evt.Skip()
+        self.client.pushClipboard()
 
-	def onSendCtrlAltDel(self, evt: wx.CommandEvent) -> None:
-		evt.Skip()
-		self.client.sendSAS()
+    def onCopyLinkItem(self, evt: wx.CommandEvent) -> None:
+        evt.Skip()
+        self.client.copyLink()
 
-	def handleConnected(self, connected: bool) -> None:
-		self.connectItem.Enable(not connected)
-		self.disconnectItem.Enable(connected)
-		self.muteItem.Enable(connected)
-		if not connected:
-			self.muteItem.Check(False)
-		self.pushClipboardItem.Enable(connected)
-		self.copyLinkItem.Enable(connected)
-		self.sendCtrlAltDelItem.Enable(connected)
+    def onSendCtrlAltDel(self, evt: wx.CommandEvent) -> None:
+        evt.Skip()
+        self.client.sendSAS()
+
+    def handleConnected(self, connected: bool) -> None:
+        self.connectItem.Enable(not connected)
+        self.disconnectItem.Enable(connected)
+        self.muteItem.Enable(connected)
+        if not connected:
+            self.muteItem.Check(False)
+        self.pushClipboardItem.Enable(connected)
+        self.copyLinkItem.Enable(connected)
+        self.sendCtrlAltDelItem.Enable(connected)

--- a/addon/globalPlugins/remoteClient/nvda_patcher.py
+++ b/addon/globalPlugins/remoteClient/nvda_patcher.py
@@ -1,13 +1,13 @@
-from typing import Any, Dict, List, Optional, Union, Type
+from typing import Any, List, Optional, Union
+
 import braille
 import brailleInput
 import inputCore
 import nvwave
 import scriptHandler
 import speech
-from speech.extensions import speechCanceled
 import tones
-import versionInfo
+from speech.extensions import speechCanceled
 
 from . import callback_manager
 

--- a/addon/globalPlugins/remoteClient/nvda_patcher.py
+++ b/addon/globalPlugins/remoteClient/nvda_patcher.py
@@ -15,19 +15,19 @@ from . import callback_manager
 class NVDAPatcher(callback_manager.CallbackManager):
 	"""Base class to manage patching of braille display changes."""
 
-	def patchSetDisplay(self) -> None:
+	def registerSetDisplay(self) -> None:
 		braille.displayChanged.register(self.handle_displayChanged)
 		braille.displaySizeChanged.register(self.handle_displaySizeChanged)
 
-	def unpatchSetDisplay(self) -> None:
+	def unregisterSetDisplay(self) -> None:
 		braille.displaySizeChanged.unregister(self.handle_displaySizeChanged)
 		braille.displayChanged.unregister(self.handle_displayChanged)
 
-	def patch(self) -> None:
-		self.patchSetDisplay()
+	def register(self) -> None:
+		self.registerSetDisplay()
 
-	def unpatch(self) -> None:
-		self.unpatchSetDisplay()
+	def unregister(self) -> None:
+		self.unregisterSetDisplay()
 
 	def handle_displayChanged(self, display: Any) -> None:
 		self.callCallbacks('set_display', display=display)
@@ -52,13 +52,13 @@ class NVDASlavePatcher(NVDAPatcher):
 		self.orig_pauseSpeech = speech.pauseSpeech
 		speech.pauseSpeech = self.pauseSpeech
 
-	def patchTones(self) -> None:
+	def registerTones(self) -> None:
 		tones.decide_beep.register(self.handle_decide_beep)
 
-	def patchNvwave(self) -> None:
+	def registerNvwave(self) -> None:
 		nvwave.decide_playWaveFile.register(self.handle_decide_playWaveFile)
 
-	def patchBraille(self) -> None:
+	def registerBraille(self) -> None:
 		braille.pre_writeCells.register(self.handle_pre_writeCells)
 
 	def unpatchSpeech(self):
@@ -70,26 +70,26 @@ class NVDASlavePatcher(NVDAPatcher):
 		speech.pauseSpeech = self.orig_pauseSpeech
 		self.orig_pauseSpeech = None
 
-	def unpatchTones(self):
+	def unregisterTones(self):
 		tones.decide_beep.unregister(self.handle_decide_beep)
 
-	def unpatchNvwave(self):
+	def unregisterNvwave(self):
 		nvwave.decide_playWaveFile.unregister(self.handle_decide_playWaveFile)
 
-	def unpatchBraille(self):
+	def unregisterBraille(self):
 		braille.pre_writeCells.unregister(self.handle_pre_writeCells)
 
-	def patch(self):
+	def register(self):
 		self.patchSpeech()
-		self.patchTones()
-		self.patchNvwave()
-		self.patchBraille()
+		self.registerTones()
+		self.registerNvwave()
+		self.registerBraille()
 
-	def unpatch(self):
+	def unregister(self):
 		self.unpatchSpeech()
-		self.unpatchTones()
-		self.unpatchNvwave()
-		self.unpatchBraille()
+		self.unregisterTones()
+		self.unregisterNvwave()
+		self.unregisterBraille()
 
 	def speak(self, speechSequence: Any, priority: Any) -> None:
 		self.callCallbacks('speak', speechSequence=speechSequence, priority=priority)
@@ -116,20 +116,20 @@ class NVDASlavePatcher(NVDAPatcher):
 class NVDAMasterPatcher(NVDAPatcher):
 	"""Class to manage patching of braille input."""
 
-	def patchBrailleInput(self) -> None:
+	def registerBrailleInput(self) -> None:
 		inputCore.decide_executeGesture.register(self.handle_decide_executeGesture)
 
-	def unpatchBrailleInput(self) -> None:
+	def unregisterBrailleInput(self) -> None:
 		inputCore.decide_executeGesture.unregister(self.handle_decide_executeGesture)
 
-	def patch(self):
-		super().patch()
+	def register(self):
+		super().register()
 		# We do not patch braille input by default
 
-	def unpatch(self):
-		super().unpatch()
+	def unregister(self):
+		super().unregister()
 		# To be sure, unpatch braille input
-		self.unpatchBrailleInput()
+		self.unregisterBrailleInput()
 
 	def handle_decide_executeGesture(self, gesture: Union[braille.BrailleDisplayGesture, brailleInput.BrailleInputGesture, Any]) -> bool:
 		if isinstance(gesture,(braille.BrailleDisplayGesture,brailleInput.BrailleInputGesture)):

--- a/addon/globalPlugins/remoteClient/protocol.py
+++ b/addon/globalPlugins/remoteClient/protocol.py
@@ -38,3 +38,7 @@ class RemoteMessageType(Enum):
     nvda_not_connected = "nvda_not_connected" # This was added in version 2 but never implemented on the server
 
 
+SERVER_PORT = 6837
+URL_PREFIX = 'nvdaremote://'
+
+

--- a/addon/globalPlugins/remoteClient/protocol.py
+++ b/addon/globalPlugins/remoteClient/protocol.py
@@ -19,6 +19,7 @@ class RemoteMessageType(Enum):
     tone = "tone"
     wave = "wave"
     send_SAS = "send_SAS"  # Send Secure Attention Sequence
+    index = "index"
     
     # Display and Braille Messages
     display = "display"
@@ -30,7 +31,10 @@ class RemoteMessageType(Enum):
     set_clipboard_text = "set_clipboard_text"
     
     # System Messages
+    motd = "motd"
+    version_mismatch = "version_mismatch"
     ping = "ping"
     error = "error"
+    nvda_not_connected = "nvda_not_connected" # This was added in version 2 but never implemented on the server
 
 

--- a/addon/globalPlugins/remoteClient/secureDesktop.py
+++ b/addon/globalPlugins/remoteClient/secureDesktop.py
@@ -81,13 +81,8 @@ class SecureDesktopHandler:
 			self.leave_secure_desktop()
 			
 		if self._slave_session is not None and self._slave_session.transport is not None:
-			try:
-				self._slave_session.transport.callback_manager.unregisterCallback(
-				'msg_set_braille_info',
-				self._on_master_display_change
-			)
-			except ValueError:
-				pass
+			transport = self._slave_session.transport
+			transport.unregisterInbound(RemoteMessageType.set_braille_info, self._on_master_display_change)
 		self._slave_session = session
 
 	def _on_secure_desktop_change(self, isSecureDesktop: Optional[bool] = None) -> None:
@@ -124,8 +119,8 @@ class SecureDesktopHandler:
 			channel=channel,
 			insecure=True
 		)
-		self.sd_relay.callback_manager.registerCallback('msg_client_joined', self._on_master_display_change)
-		self.slave_session.transport.callback_manager.registerCallback('msg_set_braille_info', self._on_master_display_change)
+		self.sd_relay.registerInbound(RemoteMessageType.client_joined, self._on_master_display_change)
+		self.slave_session.transport.registerInbound(RemoteMessageType.set_braille_info, self._on_master_display_change)
 		
 		self.sd_bridge = bridge.BridgeTransport(self.slave_session.transport, self.sd_relay)
 		
@@ -154,10 +149,7 @@ class SecureDesktopHandler:
 			self.sd_relay = None
 
 		if self.slave_session is not None and self.slave_session.transport is not None:
-			self.slave_session.transport.callback_manager.unregisterCallback(
-				'msg_set_braille_info',
-				self._on_master_display_change
-			)
+			self.slave_session.transport.unregisterInbound(RemoteMessageType.set_braille_info, self._on_master_display_change)
 			self.slave_session.setDisplaySize()
 		
 		try:

--- a/addon/globalPlugins/remoteClient/secureDesktop.py
+++ b/addon/globalPlugins/remoteClient/secureDesktop.py
@@ -1,22 +1,21 @@
-from dataclasses import dataclass
 import json
 import socket
 import ssl
 import threading
 import uuid
-from typing import Optional, Tuple, Any
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional, Tuple
 
 import shlobj
-
-from pathlib import Path
 from logHandler import log
 from winAPI.secureDesktop import post_secureDesktopStateChange
 
 from . import bridge, server
 from .protocol import RemoteMessageType
-from .transport import RelayTransport
-from .session import SlaveSession
 from .serializer import JSONSerializer
+from .session import SlaveSession
+from .transport import RelayTransport
 
 
 def get_program_data_temp_path() -> Path:

--- a/addon/globalPlugins/remoteClient/server.py
+++ b/addon/globalPlugins/remoteClient/server.py
@@ -1,15 +1,14 @@
-from enum import Enum
 import logging
-from .protocol import RemoteMessageType
-from .serializer import JSONSerializer
-
 import os
 import socket
 import ssl
-import sys
 import time
+from enum import Enum
 from select import select
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple
+
+from .protocol import RemoteMessageType
+from .serializer import JSONSerializer
 
 logger = logging.getLogger(__name__)
 
@@ -131,7 +130,7 @@ class Client:
 			# [2] https://docs.python.org/3.7/library/socket.html#socket.socket.recv
 			buffSize = 16384
 			sock_Data = self.socket.recv(buffSize)
-		except:
+		except Exception:
 			self.close()
 			return
 		if not sock_Data:  # Disconnect
@@ -212,7 +211,7 @@ class Client:
 		try:
 			data = self.serializer.serialize(type=type, **msg)
 			self.socket.sendall(data)
-		except:
+		except Exception:
 			self.close()
 
 	def send_to_others(self, origin: Optional[int] = None, **obj: Any) -> None:

--- a/addon/globalPlugins/remoteClient/session.py
+++ b/addon/globalPlugins/remoteClient/session.py
@@ -78,7 +78,7 @@ Please either use a different server or upgrade your version of the addon.""")
 class SlaveSession(RemoteSession):
 	"""Session that runs on the slave and manages state."""
 
-	mode: str = 'slave'
+	mode: connection_info.ConnectionMode = connection_info.ConnectionMode.SLAVE
 	patcher: nvda_patcher.NVDASlavePatcher
 	masters: Dict[int, Dict[str, Any]]
 	masterDisplaySizes: List[int]
@@ -218,7 +218,7 @@ class SlaveSession(RemoteSession):
 
 class MasterSession(RemoteSession):
 
-	mode: str = 'master'
+	mode: connection_info.ConnectionMode = connection_info.ConnectionMode.MASTER
 	patcher: nvda_patcher.NVDAMasterPatcher
 	slaves: Dict[int, Dict[str, Any]]
 	patchCallbacksAdded: bool

--- a/addon/globalPlugins/remoteClient/session.py
+++ b/addon/globalPlugins/remoteClient/session.py
@@ -36,8 +36,8 @@ class RemoteSession:
 	mode: Optional[str] = None
 	patcher: Optional[nvda_patcher.NVDAPatcher]
 
-	def __init__(self, local_machine: local_machine.LocalMachine, transport: RelayTransport) -> None:
-		self.localMachine = local_machine
+	def __init__(self, localMachine: local_machine.LocalMachine, transport: RelayTransport) -> None:
+		self.localMachine = localMachine
 		self.patcher = None
 		self.transport = transport
 		self.transport.registerInbound(RemoteMessageType.version_mismatch, self.handleVersionMismatch)
@@ -84,8 +84,8 @@ class SlaveSession(RemoteSession):
 	masterDisplaySizes: List[int]
 	patchCallbacksAdded: bool
 
-	def __init__(self, *args: Any) -> None:
-		super().__init__(*args)
+	def __init__(self, localMachine: local_machine.LocalMachine, transport: RelayTransport) -> None:
+		super().__init__(localMachine, transport)
 		self.transport.registerInbound(RemoteMessageType.client_joined, self.handleClientConnected)
 		self.transport.registerInbound(RemoteMessageType.client_left, self.handleClientDisconnected)
 		self.transport.registerInbound(RemoteMessageType.key, self.localMachine.sendKey)
@@ -223,8 +223,8 @@ class MasterSession(RemoteSession):
 	slaves: Dict[int, Dict[str, Any]]
 	patchCallbacksAdded: bool
 
-	def __init__(self, *args: Any) -> None:
-		super().__init__(*args)
+	def __init__(self, localMachine: local_machine.LocalMachine, transport: RelayTransport) -> None:
+		super().__init__(localMachine, transport)
 		self.slaves = defaultdict(dict)
 		self.patcher = nvda_patcher.NVDAMasterPatcher()
 		self.patchCallbacksAdded = False

--- a/addon/globalPlugins/remoteClient/session.py
+++ b/addon/globalPlugins/remoteClient/session.py
@@ -105,7 +105,7 @@ class SlaveSession(RemoteSession):
 		self.transport.registerInbound(RemoteMessageType.send_SAS, self.localMachine.sendSAS)
 
 	def handleClientConnected(self, client: Optional[Dict[str, Any]] = None) -> None:
-		self.patcher.patch()
+		self.patcher.register()
 		if not self.patchCallbacksAdded:
 			self.addPatchCallbacks()
 			self.patchCallbacksAdded = True
@@ -120,21 +120,21 @@ class SlaveSession(RemoteSession):
 			self.handleClientConnected(client)
 
 	def handleTransportClosing(self) -> None:
-		self.patcher.unpatch()
+		self.patcher.unregister()
 		if self.patchCallbacksAdded:
 			self.removePatchCallbacks()
 			self.patchCallbacksAdded = False
 
 	def handleTransportDisconnected(self):
 		cues.client_connected()
-		self.patcher.unpatch()
+		self.patcher.unregister()
 
 	def handleClientDisconnected(self, client=None):
 		cues.client_disconnected()
 		if client['connection_type'] == 'master':
 			del self.masters[client['id']]
 		if not self.masters:
-			self.patcher.unpatch()
+			self.patcher.unregister()
 
 	def setDisplaySize(self, sizes=None):
 		self.masterDisplaySizes = sizes if sizes else [
@@ -275,7 +275,7 @@ class MasterSession(RemoteSession):
 			self.handleClientConnected(client)
 
 	def handleClientConnected(self, client=None):
-		self.patcher.patch()
+		self.patcher.register()
 		if not self.patchCallbacksAdded:
 			self.addPatchCallbacks()
 			self.patchCallbacksAdded = True
@@ -283,7 +283,7 @@ class MasterSession(RemoteSession):
 		cues.client_connected()
 
 	def handleClientDisconnected(self, client=None):
-		self.patcher.unpatch()
+		self.patcher.unregister()
 		if self.patchCallbacksAdded:
 			self.removePatchCallbacks()
 			self.patchCallbacksAdded = False

--- a/addon/globalPlugins/remoteClient/settings_panel.py
+++ b/addon/globalPlugins/remoteClient/settings_panel.py
@@ -84,7 +84,7 @@ class RemoteSettingsPanel(SettingsPanel):
 	def on_delete_fingerprints(self, evt: wx.CommandEvent) -> None:
 		if gui.messageBox(_("When connecting to an unauthorized server, you will again be prompted to accepts its certificate."), _("Are you sure you want to delete all stored trusted fingerprints?"), wx.YES|wx.NO|wx.NO_DEFAULT|wx.ICON_WARNING) == wx.YES:
 			self.config['trusted_certs'].clear()
-			self.config.write()
+			configuration.save_config()
 		evt.Skip()
 
 	def isValid(self) -> bool:
@@ -110,7 +110,7 @@ class RemoteSettingsPanel(SettingsPanel):
 			cs['port'] = int(self.port.GetValue())
 		cs['key'] = self.key.GetValue()
 		self.config['ui']['play_sounds'] = self.play_sounds.GetValue()
-		self.config.write()
+		configuration.save_config()
 
 	def onSave(self):
 		self.write_to_config()

--- a/addon/globalPlugins/remoteClient/socket_utils.py
+++ b/addon/globalPlugins/remoteClient/socket_utils.py
@@ -1,16 +1,16 @@
 import urllib.parse
 
-SERVER_PORT = 6837
+from .protocol import SERVER_PORT
 
-def address_to_hostport(addr):
+def addressToHostPort(addr):
 	"""Converts an address such as google.com:80 into a tuple of (address, port).
 	If no port is given, use SERVER_PORT."""
 	addr = urllib.parse.urlparse('//'+addr)
 	port = addr.port or SERVER_PORT
 	return (addr.hostname, port)
 
-def hostport_to_address(hostport):
-	host, port = hostport
+def hostPortToAddress(hostPort):
+	host, port = hostPort
 	if ':' in host:
 		host = '[' + host + ']'
 	if port != SERVER_PORT:

--- a/addon/globalPlugins/remoteClient/socket_utils.py
+++ b/addon/globalPlugins/remoteClient/socket_utils.py
@@ -3,7 +3,7 @@ import urllib.parse
 SERVER_PORT = 6837
 
 def address_to_hostport(addr):
-	"""Converts an address such as google.com:80 into an address adn port tuple.
+	"""Converts an address such as google.com:80 into a tuple of (address, port).
 	If no port is given, use SERVER_PORT."""
 	addr = urllib.parse.urlparse('//'+addr)
 	port = addr.port or SERVER_PORT

--- a/addon/globalPlugins/remoteClient/transport.py
+++ b/addon/globalPlugins/remoteClient/transport.py
@@ -533,11 +533,11 @@ class ConnectorThread(threading.Thread):
 	"""
 	running: bool
 	connector: Transport
-	connect_delay: int
+	reconnectDelay: int
 
-	def __init__(self, connector: Transport, connect_delay: int = 5) -> None:
+	def __init__(self, connector: Transport, reconnectDelay: int = 5) -> None:
 		super().__init__()
-		self.connect_delay = connect_delay
+		self.reconnectDelay = reconnectDelay
 		self.running = True
 		self.connector = connector
 		self.name = self.name + "_connector_loop"
@@ -548,10 +548,10 @@ class ConnectorThread(threading.Thread):
 			try:
 				self.connector.run()
 			except socket.error:
-				time.sleep(self.connect_delay)
+				time.sleep(self.reconnectDelay)
 				continue
 			else:
-				time.sleep(self.connect_delay)
+				time.sleep(self.reconnectDelay)
 		log.info("Ending control connector thread %s" % self.name)
 
 def clear_queue(queue: Queue[Optional[bytes]]) -> None:

--- a/addon/globalPlugins/remoteClient/transport.py
+++ b/addon/globalPlugins/remoteClient/transport.py
@@ -4,13 +4,13 @@ This module provides the core networking functionality for NVDA Remote.
 
 Classes:
     Transport: Base class defining the transport interface
-    TCPTransport: Implementation of secure TCP socket transport  
+    TCPTransport: Implementation of secure TCP socket transport
     RelayTransport: Extended TCP transport for relay server connections
     ConnectorThread: Helper class for connection management
 
 The transport layer handles:
     * Secure socket connections with SSL/TLS
-    * Message serialization and deserialization 
+    * Message serialization and deserialization
     * Connection management and reconnection
     * Event notifications for connection state changes
     * Message routing based on RemoteMessageType enum
@@ -25,551 +25,584 @@ import socket
 import ssl
 import threading
 import time
-from collections import defaultdict
+from enum import Enum
 from logging import getLogger
 from queue import Queue
 from typing import Any, Callable, Dict, Optional, Tuple, Union
-from enum import Enum
 
-from extensionPoints import Action
 import wx
-
-log = getLogger('transport')
-
+from extensionPoints import Action
 
 from . import configuration
+from .protocol import PROTOCOL_VERSION, RemoteMessageType
 from .serializer import Serializer
-from .socket_utils import addressToHostPort, hostPortToAddress
-from .protocol import SERVER_PORT, RemoteMessageType, PROTOCOL_VERSION
-from .serializer import Serializer
+from .socket_utils import hostPortToAddress
+
+log = getLogger("transport")
 
 
 class Transport:
-	"""Base class defining the network transport interface for NVDA Remote.
-	
-	This abstract base class defines the interface that all network transports must implement.
-	It provides core functionality for secure message passing, connection management,
-	and event handling between NVDA instances.
-	
-	The Transport class handles:
-	
-	* Message serialization and routing using a pluggable serializer
-	* Connection state management and event notifications
-	* Registration of message type handlers
-	* Thread-safe connection events
-	
-	To implement a new transport:
-	
-	1. Subclass Transport
-	2. Implement connection logic in run()
-	3. Call onTransportConnected() when connected
-	4. Use send() to transmit messages
-	5. Call appropriate event notifications
-	
-	Example:
-	    >>> serializer = JSONSerializer()
-	    >>> transport = TCPTransport(serializer, ("localhost", 8090))
-	    >>> transport.registerInbound(RemoteMessageType.key, handle_key)
-	    >>> transport.run()
-	
-	Args:
-	    serializer: The serializer instance to use for message encoding/decoding
-	
-	Attributes:
-	    connected (bool): True if transport has an active connection
-	    successful_connects (int): Counter of successful connection attempts
-	    connected_event (threading.Event): Event that is set when connected
-	    serializer (Serializer): The message serializer instance
-	    inboundHandlers (Dict[RemoteMessageType, Callable]): Registered message handlers
-	
-	Events:
-	    transportConnected: Fired after connection is established and ready
-	    transportDisconnected: Fired when existing connection is lost
-	    transportCertificateAuthenticationFailed: Fired when SSL certificate validation fails
-	    transportConnectionFailed: Fired when a connection attempt fails
-	    transportClosing: Fired before transport is shut down
-	"""
-	connected: bool
-	successfulConnects: int
-	connectedEvent: threading.Event 
-	serializer: Serializer
+    """Base class defining the network transport interface for NVDA Remote.
 
+    This abstract base class defines the interface that all network transports must implement.
+    It provides core functionality for secure message passing, connection management,
+    and event handling between NVDA instances.
 
-	def __init__(self, serializer: Serializer) -> None:
-		self.serializer = serializer
-		self.connected = False
-		self.successfulConnects = 0
-		self.connectedEvent = threading.Event()
-		# iterate over all the message types and create a dictionary of handlers mapping to Action()
-		self.inboundHandlers: Dict[RemoteMessageType, Callable] = {msg: Action() for msg in RemoteMessageType}
-		self.transportConnected = Action()
-		"""
+    The Transport class handles:
+
+    * Message serialization and routing using a pluggable serializer
+    * Connection state management and event notifications
+    * Registration of message type handlers
+    * Thread-safe connection events
+
+    To implement a new transport:
+
+    1. Subclass Transport
+    2. Implement connection logic in run()
+    3. Call onTransportConnected() when connected
+    4. Use send() to transmit messages
+    5. Call appropriate event notifications
+
+    Example:
+        >>> serializer = JSONSerializer()
+        >>> transport = TCPTransport(serializer, ("localhost", 8090))
+        >>> transport.registerInbound(RemoteMessageType.key, handle_key)
+        >>> transport.run()
+
+    Args:
+        serializer: The serializer instance to use for message encoding/decoding
+
+    Attributes:
+        connected (bool): True if transport has an active connection
+        successful_connects (int): Counter of successful connection attempts
+        connected_event (threading.Event): Event that is set when connected
+        serializer (Serializer): The message serializer instance
+        inboundHandlers (Dict[RemoteMessageType, Callable]): Registered message handlers
+
+    Events:
+        transportConnected: Fired after connection is established and ready
+        transportDisconnected: Fired when existing connection is lost
+        transportCertificateAuthenticationFailed: Fired when SSL certificate validation fails
+        transportConnectionFailed: Fired when a connection attempt fails
+        transportClosing: Fired before transport is shut down
+    """
+
+    connected: bool
+    successfulConnects: int
+    connectedEvent: threading.Event
+    serializer: Serializer
+
+    def __init__(self, serializer: Serializer) -> None:
+        self.serializer = serializer
+        self.connected = False
+        self.successfulConnects = 0
+        self.connectedEvent = threading.Event()
+        # iterate over all the message types and create a dictionary of handlers mapping to Action()
+        self.inboundHandlers: Dict[RemoteMessageType, Callable] = {
+            msg: Action() for msg in RemoteMessageType
+        }
+        self.transportConnected = Action()
+        """
 		Notifies when the transport is connected
 		"""
-		self.transportDisconnected = Action()
-		"""
+        self.transportDisconnected = Action()
+        """
 		Notifies when the transport is disconnected
 		"""
-		self.transportCertificateAuthenticationFailed = Action()
-		"""
+        self.transportCertificateAuthenticationFailed = Action()
+        """
 		Notifies when the transport fails to authenticate the certificate
 		"""
-		self.transportConnectionFailed = Action()
-		"""
+        self.transportConnectionFailed = Action()
+        """
 		Notifies when the transport fails to connect
 		"""
-		self.transportClosing = Action()
-		"""
+        self.transportClosing = Action()
+        """
 		Notifies when the transport is closing
 		"""
 
-	def onTransportConnected(self) -> None:
-		"""Handle successful transport connection.
+    def onTransportConnected(self) -> None:
+        """Handle successful transport connection.
 
-		Called internally when a connection is established. Updates connection state,
-		increments successful connection counter, and notifies listeners.
+        Called internally when a connection is established. Updates connection state,
+        increments successful connection counter, and notifies listeners.
 
-		This method:
-		1. Increments successful connection counter
-		2. Sets connected flag to True
-		3. Sets the connected event
-		4. Notifies transportConnected listeners
-		"""
-		self.successfulConnects += 1
-		self.connected = True
-		self.connectedEvent.set()
-		self.transportConnected.notify()
+        This method:
+        1. Increments successful connection counter
+        2. Sets connected flag to True
+        3. Sets the connected event
+        4. Notifies transportConnected listeners
+        """
+        self.successfulConnects += 1
+        self.connected = True
+        self.connectedEvent.set()
+        self.transportConnected.notify()
 
-	def registerInbound(self, type: RemoteMessageType, handler: Callable) -> None:
-		"""Register a handler for incoming messages of a specific type.
+    def registerInbound(self, type: RemoteMessageType, handler: Callable) -> None:
+        """Register a handler for incoming messages of a specific type.
 
-		Adds a callback function to handle messages of the specified RemoteMessageType.
-		Multiple handlers can be registered for the same message type.
+        Adds a callback function to handle messages of the specified RemoteMessageType.
+        Multiple handlers can be registered for the same message type.
 
-		Args:
-			type (RemoteMessageType): The message type to handle
-			handler (Callable): Callback function to process messages of this type.
-				Will be called with the message payload as kwargs.
+        Args:
+                type (RemoteMessageType): The message type to handle
+                handler (Callable): Callback function to process messages of this type.
+                        Will be called with the message payload as kwargs.
 
-		Example:
-			>>> def handle_keypress(key_code, pressed):
-			...     print(f"Key {key_code} {'pressed' if pressed else 'released'}")
-			>>> transport.registerInbound(RemoteMessageType.key_press, handle_keypress)
+        Example:
+                >>> def handle_keypress(key_code, pressed):
+                ...     print(f"Key {key_code} {'pressed' if pressed else 'released'}")
+                >>> transport.registerInbound(RemoteMessageType.key_press, handle_keypress)
 
-		Note:
-			Handlers are called asynchronously on the wx main thread via wx.CallAfter
-		"""
-		self.inboundHandlers[type].register(handler)
+        Note:
+                Handlers are called asynchronously on the wx main thread via wx.CallAfter
+        """
+        self.inboundHandlers[type].register(handler)
 
-	def unregisterInbound(self, type: RemoteMessageType, handler: Callable) -> None:
-		"""Remove a previously registered message handler.
+    def unregisterInbound(self, type: RemoteMessageType, handler: Callable) -> None:
+        """Remove a previously registered message handler.
 
-		Removes a specific handler function from the list of handlers for a message type.
-		If the handler was not previously registered, this is a no-op.
+        Removes a specific handler function from the list of handlers for a message type.
+        If the handler was not previously registered, this is a no-op.
 
-		Args:
-			type (RemoteMessageType): The message type to unregister from
-			handler (Callable): The handler function to remove
+        Args:
+                type (RemoteMessageType): The message type to unregister from
+                handler (Callable): The handler function to remove
 
-		Example:
-			>>> transport.unregisterInbound(RemoteMessageType.key_press, handle_keypress)
-			
-		Note:
-			Must pass the exact same handler function that was previously registered
-		"""
-		self.inboundHandlers[type].unregister(handler)
+        Example:
+                >>> transport.unregisterInbound(RemoteMessageType.key_press, handle_keypress)
+
+        Note:
+                Must pass the exact same handler function that was previously registered
+        """
+        self.inboundHandlers[type].unregister(handler)
+
 
 class TCPTransport(Transport):
-	"""Secure TCP socket transport implementation.
-	
-	This class implements the Transport interface using TCP sockets with SSL/TLS
-	encryption. It handles connection establishment, data transfer, and connection
-	lifecycle management.
-	
-	Args:
-	    serializer (Serializer): Message serializer instance
-	    address (Tuple[str, int]): Remote address to connect to
-	    timeout (int, optional): Connection timeout in seconds. Defaults to 0.
-	    insecure (bool, optional): Skip certificate verification. Defaults to False.
-	
-	Attributes:
-	    buffer (bytes): Buffer for incomplete received data
-	    closed (bool): Whether transport is closed
-	    queue (Queue[Optional[bytes]]): Queue of outbound messages
-	    insecure (bool): Whether to skip certificate verification
-	    address (Tuple[str, int]): Remote address to connect to
-	    timeout (int): Connection timeout in seconds
-	    serverSock (Optional[ssl.SSLSocket]): The SSL socket connection
-	    serverSockLock (threading.Lock): Lock for thread-safe socket access
-	    queueThread (Optional[threading.Thread]): Thread handling outbound messages
-	    reconnectorThread (ConnectorThread): Thread managing reconnection
-	"""
-	buffer: bytes
-	closed: bool
-	queue: Queue[Optional[bytes]]
-	insecure: bool
-	serverSockLock: threading.Lock
-	address: Tuple[str, int]
-	serverSock: Optional[ssl.SSLSocket]
-	queueThread: Optional[threading.Thread]
-	timeout: int
-	reconnectorThread: 'ConnectorThread'
-	lastFailFingerprint: Optional[str]
-	
-	def __init__(self, serializer: Serializer, address: Tuple[str, int], timeout: int = 0, insecure: bool = False) -> None:
-		super().__init__(serializer=serializer)
-		self.closed = False
-		#Buffer to hold partially received data
-		self.buffer = B''
-		self.queue = Queue()
-		self.address = address
-		self.serverSock = None
-		# Reading/writing from an SSL socket is not thread safe.
-		# See https://bugs.python.org/issue41597#msg375692
-		# Guard access to the socket with a lock.
-		self.serverSockLock = threading.Lock()
-		self.queueThread = None
-		self.timeout = timeout
-		self.reconnectorThread = ConnectorThread(self)
-		self.insecure=insecure
+    """Secure TCP socket transport implementation.
 
-	def run(self) -> None:
-		self.closed = False
-		try:
-			self.serverSock = self.create_outbound_socket(*self.address, insecure=self.insecure)
-			self.serverSock.connect(self.address)
-		except ssl.SSLCertVerificationError as ex:
-			fingerprint=None
-			try:
-				tmp_con = self.create_outbound_socket(*self.address, insecure = True)
-				tmp_con.connect(self.address)
-				certBin = tmp_con.getpeercert(True)
-				tmp_con.close()
-				fingerprint = hashlib.sha256(certBin).hexdigest().lower()
-			except Exception: pass
-			config = configuration.get_config()
-			if hostPortToAddress(self.address) in config['trusted_certs'] and config['trusted_certs'][hostPortToAddress(self.address)]==fingerprint:
-				self.insecure=True
-				return self.run()
-			self.lastFailFingerprint = fingerprint
-			self.transportCertificateAuthenticationFailed.notify()
-			raise
-		except Exception:
-			self.transportConnectionFailed.notify()
-			raise
-		self.onTransportConnected()
-		self.queueThread = threading.Thread(target=self.sendQueue)
-		self.queueThread.daemon = True
-		self.queueThread.start()
-		while self.serverSock is not None:
-			try:
-				readers, writers, error = select.select([self.serverSock], [], [self.serverSock])
-			except socket.error:
-				self.buffer = b''
-				break
-			if self.serverSock in error:
-				self.buffer = b""
-				break
-			if self.serverSock in readers:
-				try:
-					self.processIncomingSocketData()
-				except socket.error:
-					self.buffer = b''
-					break
-		self.connected = False
-		self.connectedEvent.clear()
-		self.transportDisconnected.notify()
-		self._disconnect()
+    This class implements the Transport interface using TCP sockets with SSL/TLS
+    encryption. It handles connection establishment, data transfer, and connection
+    lifecycle management.
 
-	def create_outbound_socket(self, host: str, port: int, insecure: bool = False) -> ssl.SSLSocket:
-		"""Create and configure an SSL socket for outbound connections.
+    Args:
+        serializer (Serializer): Message serializer instance
+        address (Tuple[str, int]): Remote address to connect to
+        timeout (int, optional): Connection timeout in seconds. Defaults to 0.
+        insecure (bool, optional): Skip certificate verification. Defaults to False.
 
-		Creates a TCP socket with appropriate timeout and keep-alive settings,
-		then wraps it with SSL/TLS encryption.
+    Attributes:
+        buffer (bytes): Buffer for incomplete received data
+        closed (bool): Whether transport is closed
+        queue (Queue[Optional[bytes]]): Queue of outbound messages
+        insecure (bool): Whether to skip certificate verification
+        address (Tuple[str, int]): Remote address to connect to
+        timeout (int): Connection timeout in seconds
+        serverSock (Optional[ssl.SSLSocket]): The SSL socket connection
+        serverSockLock (threading.Lock): Lock for thread-safe socket access
+        queueThread (Optional[threading.Thread]): Thread handling outbound messages
+        reconnectorThread (ConnectorThread): Thread managing reconnection
+    """
 
-		Args:
-			host (str): Remote hostname to connect to
-			port (int): Remote port number
-			insecure (bool, optional): Skip certificate verification. Defaults to False.
+    buffer: bytes
+    closed: bool
+    queue: Queue[Optional[bytes]]
+    insecure: bool
+    serverSockLock: threading.Lock
+    address: Tuple[str, int]
+    serverSock: Optional[ssl.SSLSocket]
+    queueThread: Optional[threading.Thread]
+    timeout: int
+    reconnectorThread: "ConnectorThread"
+    lastFailFingerprint: Optional[str]
 
-		Returns:
-			ssl.SSLSocket: Configured SSL socket ready for connection
+    def __init__(
+        self,
+        serializer: Serializer,
+        address: Tuple[str, int],
+        timeout: int = 0,
+        insecure: bool = False,
+    ) -> None:
+        super().__init__(serializer=serializer)
+        self.closed = False
+        # Buffer to hold partially received data
+        self.buffer = b""
+        self.queue = Queue()
+        self.address = address
+        self.serverSock = None
+        # Reading/writing from an SSL socket is not thread safe.
+        # See https://bugs.python.org/issue41597#msg375692
+        # Guard access to the socket with a lock.
+        self.serverSockLock = threading.Lock()
+        self.queueThread = None
+        self.timeout = timeout
+        self.reconnectorThread = ConnectorThread(self)
+        self.insecure = insecure
 
-		Note:
-			The socket is created but not yet connected. Call connect() separately.
-		"""
-		address = socket.getaddrinfo(host, port)[0]
-		serverSock = socket.socket(*address[:3])
-		if self.timeout:
-			serverSock.settimeout(self.timeout)
-		serverSock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-		serverSock.ioctl(socket.SIO_KEEPALIVE_VALS, (1, 60000, 2000))
-		ctx = (ssl.SSLContext())
-		if insecure: ctx.verify_mode = ssl.CERT_NONE
-		ctx.check_hostname = not insecure
-		ctx.load_default_certs()
-		serverSock = ctx.wrap_socket(sock=serverSock, server_hostname=host)
-		return serverSock
+    def run(self) -> None:
+        self.closed = False
+        try:
+            self.serverSock = self.create_outbound_socket(
+                *self.address, insecure=self.insecure
+            )
+            self.serverSock.connect(self.address)
+        except ssl.SSLCertVerificationError:
+            fingerprint = None
+            try:
+                tmp_con = self.create_outbound_socket(*self.address, insecure=True)
+                tmp_con.connect(self.address)
+                certBin = tmp_con.getpeercert(True)
+                tmp_con.close()
+                fingerprint = hashlib.sha256(certBin).hexdigest().lower()
+            except Exception:
+                pass
+            config = configuration.get_config()
+            if (
+                hostPortToAddress(self.address) in config["trusted_certs"]
+                and config["trusted_certs"][hostPortToAddress(self.address)]
+                == fingerprint
+            ):
+                self.insecure = True
+                return self.run()
+            self.lastFailFingerprint = fingerprint
+            self.transportCertificateAuthenticationFailed.notify()
+            raise
+        except Exception:
+            self.transportConnectionFailed.notify()
+            raise
+        self.onTransportConnected()
+        self.queueThread = threading.Thread(target=self.sendQueue)
+        self.queueThread.daemon = True
+        self.queueThread.start()
+        while self.serverSock is not None:
+            try:
+                readers, writers, error = select.select(
+                    [self.serverSock], [], [self.serverSock]
+                )
+            except socket.error:
+                self.buffer = b""
+                break
+            if self.serverSock in error:
+                self.buffer = b""
+                break
+            if self.serverSock in readers:
+                try:
+                    self.processIncomingSocketData()
+                except socket.error:
+                    self.buffer = b""
+                    break
+        self.connected = False
+        self.connectedEvent.clear()
+        self.transportDisconnected.notify()
+        self._disconnect()
 
-	def getpeercert(self, binary_form: bool = False) -> Optional[Union[Dict[str, Any], bytes]]:
-		"""Get the certificate from the peer.
+    def create_outbound_socket(
+        self, host: str, port: int, insecure: bool = False
+    ) -> ssl.SSLSocket:
+        """Create and configure an SSL socket for outbound connections.
 
-		Retrieves the certificate presented by the remote peer during SSL handshake.
+        Creates a TCP socket with appropriate timeout and keep-alive settings,
+        then wraps it with SSL/TLS encryption.
 
-		Args:
-			binary_form (bool, optional): If True, return the raw certificate bytes.
-				If False, return a parsed dictionary. Defaults to False.
+        Args:
+                host (str): Remote hostname to connect to
+                port (int): Remote port number
+                insecure (bool, optional): Skip certificate verification. Defaults to False.
 
-		Returns:
-			Optional[Union[Dict[str, Any], bytes]]: The peer's certificate, or None if not connected.
-				Format depends on binary_form parameter.
-		"""
-		if self.serverSock is None:
-			return None
-		return self.serverSock.getpeercert(binary_form)
+        Returns:
+                ssl.SSLSocket: Configured SSL socket ready for connection
 
-	def processIncomingSocketData(self) -> None:
-		"""Process incoming data from the server socket.
+        Note:
+                The socket is created but not yet connected. Call connect() separately.
+        """
+        address = socket.getaddrinfo(host, port)[0]
+        serverSock = socket.socket(*address[:3])
+        if self.timeout:
+            serverSock.settimeout(self.timeout)
+        serverSock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        serverSock.ioctl(socket.SIO_KEEPALIVE_VALS, (1, 60000, 2000))
+        ctx = ssl.SSLContext()
+        if insecure:
+            ctx.verify_mode = ssl.CERT_NONE
+        ctx.check_hostname = not insecure
+        ctx.load_default_certs()
+        serverSock = ctx.wrap_socket(sock=serverSock, server_hostname=host)
+        return serverSock
 
-		Reads available data from the socket, buffers partial messages,
-		and processes complete messages by passing them to parse().
+    def getpeercert(
+        self, binary_form: bool = False
+    ) -> Optional[Union[Dict[str, Any], bytes]]:
+        """Get the certificate from the peer.
 
-		Messages are expected to be newline-delimited.
-		Partial messages are stored in self.buffer until complete.
+        Retrieves the certificate presented by the remote peer during SSL handshake.
 
-		Note:
-			This method handles SSL-specific socket behavior and non-blocking reads.
-			It is called when select() indicates data is available.
-		"""
-		# This approach may be problematic:
-		# See also server.py handle_data in class Client.
-		buffSize = 16384
-		with self.serverSockLock:
-			# select operates on the raw socket. Even though it said there was data to
-			# read, that might be SSL data which might not result in actual data for
-			# us. Therefore, do a non-blocking read so SSL doesn't try to wait for
-			# more data for us.
-			# We don't make the socket non-blocking earlier because then we'd have to
-			# handle retries during the SSL handshake.
-			# See https://stackoverflow.com/questions/3187565/select-and-ssl-in-python
-			# and https://docs.python.org/3/library/ssl.html#notes-on-non-blocking-sockets
-			self.serverSock.setblocking(False)
-			try:
-				data = self.buffer + self.serverSock.recv(buffSize)
-			except ssl.SSLWantReadError:
-				# There's no data for us.
-				return
-			finally:
-				self.serverSock.setblocking(True)
-		self.buffer = b''
-		if not data:
-			self._disconnect()
-			return
-		if b'\n' not in data:
-			self.buffer += data
-			return
-		while b'\n' in data:
-			line, sep, data = data.partition(b'\n')
-			self.parse(line)
-		self.buffer += data
+        Args:
+                binary_form (bool, optional): If True, return the raw certificate bytes.
+                        If False, return a parsed dictionary. Defaults to False.
 
-	def parse(self, line: bytes) -> None:
-		"""Parse and handle a complete message line.
+        Returns:
+                Optional[Union[Dict[str, Any], bytes]]: The peer's certificate, or None if not connected.
+                        Format depends on binary_form parameter.
+        """
+        if self.serverSock is None:
+            return None
+        return self.serverSock.getpeercert(binary_form)
 
-		Deserializes a message and routes it to the appropriate handler based on type.
+    def processIncomingSocketData(self) -> None:
+        """Process incoming data from the server socket.
 
-		Args:
-			line (bytes): Complete message line to parse
+        Reads available data from the socket, buffers partial messages,
+        and processes complete messages by passing them to parse().
 
-		Note:
-			Messages must include a 'type' field matching a RemoteMessageType enum value.
-			Handler callbacks are executed asynchronously on the wx main thread.
-			Invalid or unhandled message types are logged as errors.
-		"""
-		obj = self.serializer.deserialize(line)
-		if 'type' not in obj:
-			log.error("Received message without type: %r" % obj)
-			return
-		try:
-			messageType = RemoteMessageType(obj['type'])
-		except ValueError:
-			log.error("Received message with invalid type: %r" % obj)
-			return
-		del obj['type']
-		extensionPoint = self.inboundHandlers.get(messageType)
-		if not extensionPoint:
-			log.error("Received message with unhandled type: %r" % obj)
-			return
-		wx.CallAfter(extensionPoint.notify, **obj)
+        Messages are expected to be newline-delimited.
+        Partial messages are stored in self.buffer until complete.
 
-	def sendQueue(self) -> None:
-		"""Background thread that processes the outbound message queue.
+        Note:
+                This method handles SSL-specific socket behavior and non-blocking reads.
+                It is called when select() indicates data is available.
+        """
+        # This approach may be problematic:
+        # See also server.py handle_data in class Client.
+        buffSize = 16384
+        with self.serverSockLock:
+            # select operates on the raw socket. Even though it said there was data to
+            # read, that might be SSL data which might not result in actual data for
+            # us. Therefore, do a non-blocking read so SSL doesn't try to wait for
+            # more data for us.
+            # We don't make the socket non-blocking earlier because then we'd have to
+            # handle retries during the SSL handshake.
+            # See https://stackoverflow.com/questions/3187565/select-and-ssl-in-python
+            # and https://docs.python.org/3/library/ssl.html#notes-on-non-blocking-sockets
+            self.serverSock.setblocking(False)
+            try:
+                data = self.buffer + self.serverSock.recv(buffSize)
+            except ssl.SSLWantReadError:
+                # There's no data for us.
+                return
+            finally:
+                self.serverSock.setblocking(True)
+        self.buffer = b""
+        if not data:
+            self._disconnect()
+            return
+        if b"\n" not in data:
+            self.buffer += data
+            return
+        while b"\n" in data:
+            line, sep, data = data.partition(b"\n")
+            self.parse(line)
+        self.buffer += data
 
-		Continuously pulls messages from the queue and sends them over the socket.
-		Thread exits when None is received from the queue or a socket error occurs.
+    def parse(self, line: bytes) -> None:
+        """Parse and handle a complete message line.
 
-		Note:
-			This method runs in a separate thread and handles thread-safe socket access
-			using the serverSockLock.
-		"""
-		while True:
-			item = self.queue.get()
-			if item is None:
-				return
-			try:
-				with self.serverSockLock:
-					self.serverSock.sendall(item)
-			except socket.error:
-				return
+        Deserializes a message and routes it to the appropriate handler based on type.
 
-	def send(self, type: str|Enum, **kwargs: Any) -> None:
-		"""Send a message through the transport.
+        Args:
+                line (bytes): Complete message line to parse
 
-		Serializes and queues a message for transmission. Messages are sent
-		asynchronously by the queue thread.
+        Note:
+                Messages must include a 'type' field matching a RemoteMessageType enum value.
+                Handler callbacks are executed asynchronously on the wx main thread.
+                Invalid or unhandled message types are logged as errors.
+        """
+        obj = self.serializer.deserialize(line)
+        if "type" not in obj:
+            log.error("Received message without type: %r" % obj)
+            return
+        try:
+            messageType = RemoteMessageType(obj["type"])
+        except ValueError:
+            log.error("Received message with invalid type: %r" % obj)
+            return
+        del obj["type"]
+        extensionPoint = self.inboundHandlers.get(messageType)
+        if not extensionPoint:
+            log.error("Received message with unhandled type: %r" % obj)
+            return
+        wx.CallAfter(extensionPoint.notify, **obj)
 
-		Args:
-			type (str|Enum): Message type, typically a RemoteMessageType enum value
-			**kwargs: Message payload data to serialize
+    def sendQueue(self) -> None:
+        """Background thread that processes the outbound message queue.
 
-		Note:
-			This method is thread-safe and can be called from any thread.
-			If the transport is not connected, the message will be silently dropped.
-		"""
-		if self.connected:
-			obj = self.serializer.serialize(type=type, **kwargs)
-			self.queue.put(obj)
+        Continuously pulls messages from the queue and sends them over the socket.
+        Thread exits when None is received from the queue or a socket error occurs.
 
-	def _disconnect(self) -> None:
-		"""Internal method to disconnect the transport.
+        Note:
+                This method runs in a separate thread and handles thread-safe socket access
+                using the serverSockLock.
+        """
+        while True:
+            item = self.queue.get()
+            if item is None:
+                return
+            try:
+                with self.serverSockLock:
+                    self.serverSock.sendall(item)
+            except socket.error:
+                return
 
-		Cleans up the send queue thread, empties queued messages,
-		and closes the socket connection.
+    def send(self, type: str | Enum, **kwargs: Any) -> None:
+        """Send a message through the transport.
 
-		Note:
-			This is called internally on errors, unlike close() which is called
-			explicitly to shut down the transport.
-		"""
-		"""Disconnect the transport due to an error, without closing the connector thread."""
-		if self.queueThread is not None:
-			self.queue.put(None)
-			self.queueThread.join()
-			self.queueThread = None
-		clear_queue(self.queue)
-		if self.serverSock:
-			self.serverSock.close()
-			self.serverSock = None
+        Serializes and queues a message for transmission. Messages are sent
+        asynchronously by the queue thread.
 
-	def close(self):
-		"""Close the transport."""
-		self.transportClosing.notify()
-		self.reconnectorThread.running = False
-		self._disconnect()
-		self.closed = True
-		self.reconnectorThread = ConnectorThread(self)
+        Args:
+                type (str|Enum): Message type, typically a RemoteMessageType enum value
+                **kwargs: Message payload data to serialize
+
+        Note:
+                This method is thread-safe and can be called from any thread.
+                If the transport is not connected, the message will be silently dropped.
+        """
+        if self.connected:
+            obj = self.serializer.serialize(type=type, **kwargs)
+            self.queue.put(obj)
+        else:
+            log.error("Attempted to send message %r while not connected", type)
+
+    def _disconnect(self) -> None:
+        """Internal method to disconnect the transport.
+
+        Cleans up the send queue thread, empties queued messages,
+        and closes the socket connection.
+
+        Note:
+                This is called internally on errors, unlike close() which is called
+                explicitly to shut down the transport.
+        """
+        """Disconnect the transport due to an error, without closing the connector thread."""
+        if self.queueThread is not None:
+            self.queue.put(None)
+            self.queueThread.join()
+            self.queueThread = None
+        clear_queue(self.queue)
+        if self.serverSock:
+            self.serverSock.close()
+            self.serverSock = None
+
+    def close(self):
+        """Close the transport."""
+        self.transportClosing.notify()
+        self.reconnectorThread.running = False
+        self._disconnect()
+        self.closed = True
+        self.reconnectorThread = ConnectorThread(self)
+
 
 class RelayTransport(TCPTransport):
-	"""Transport for connecting through a relay server.
-	
-	Extends TCPTransport with relay-specific protocol handling for channels
-	and connection types. Manages protocol versioning and channel joining.
-	
-	Args:
-	    serializer (Serializer): Message serializer instance
-	    address (Tuple[str, int]): Relay server address
-	    timeout (int, optional): Connection timeout. Defaults to 0.
-	    channel (Optional[str], optional): Channel to join. Defaults to None.
-	    connection_type (Optional[str], optional): Connection type. Defaults to None.
-	    protocol_version (int, optional): Protocol version. Defaults to PROTOCOL_VERSION.
-	    insecure (bool, optional): Skip certificate verification. Defaults to False.
-	
-	Attributes:
-	    channel (Optional[str]): Relay channel name
-	    connection_type (Optional[str]): Type of relay connection
-	    protocol_version (int): Protocol version to use
-	"""
-	channel: Optional[str]
-	connection_type: Optional[str]
-	protocol_version: int
+    """Transport for connecting through a relay server.
 
-	def __init__(
-		self,
-		serializer: Serializer,
-		address: Tuple[str, int],
-		timeout: int = 0,
-		channel: Optional[str] = None,
-		connection_type: Optional[str] = None,
-		protocol_version: int = PROTOCOL_VERSION,
-		insecure: bool = False
-	) -> None:
-		super().__init__(address=address, serializer=serializer, timeout=timeout, insecure=insecure)
-		log.info("Connecting to %s channel %s" % (address, channel))
-		self.channel = channel
-		self.connection_type = connection_type
-		self.protocol_version = protocol_version
-		self.transportConnected.register(self.onConnected)
+    Extends TCPTransport with relay-specific protocol handling for channels
+    and connection types. Manages protocol versioning and channel joining.
 
+    Args:
+        serializer (Serializer): Message serializer instance
+        address (Tuple[str, int]): Relay server address
+        timeout (int, optional): Connection timeout. Defaults to 0.
+        channel (Optional[str], optional): Channel to join. Defaults to None.
+        connection_type (Optional[str], optional): Connection type. Defaults to None.
+        protocol_version (int, optional): Protocol version. Defaults to PROTOCOL_VERSION.
+        insecure (bool, optional): Skip certificate verification. Defaults to False.
 
-	def onConnected(self) -> None:
-		self.send(RemoteMessageType.protocol_version, version=self.protocol_version)
-		if self.channel is not None:
-			self.send(RemoteMessageType.join, channel=self.channel, connection_type=self.connection_type)
-		else:
-			self.send(RemoteMessageType.generate_key)
+    Attributes:
+        channel (Optional[str]): Relay channel name
+        connection_type (Optional[str]): Type of relay connection
+        protocol_version (int): Protocol version to use
+    """
+
+    channel: Optional[str]
+    connection_type: Optional[str]
+    protocol_version: int
+
+    def __init__(
+        self,
+        serializer: Serializer,
+        address: Tuple[str, int],
+        timeout: int = 0,
+        channel: Optional[str] = None,
+        connection_type: Optional[str] = None,
+        protocol_version: int = PROTOCOL_VERSION,
+        insecure: bool = False,
+    ) -> None:
+        super().__init__(
+            address=address, serializer=serializer, timeout=timeout, insecure=insecure
+        )
+        log.info("Connecting to %s channel %s" % (address, channel))
+        self.channel = channel
+        self.connection_type = connection_type
+        self.protocol_version = protocol_version
+        self.transportConnected.register(self.onConnected)
+
+    def onConnected(self) -> None:
+        self.send(RemoteMessageType.protocol_version, version=self.protocol_version)
+        if self.channel is not None:
+            self.send(
+                RemoteMessageType.join,
+                channel=self.channel,
+                connection_type=self.connection_type,
+            )
+        else:
+            self.send(RemoteMessageType.generate_key)
+
 
 class ConnectorThread(threading.Thread):
-	"""Background thread that manages connection attempts.
-	
-	Handles automatic reconnection with configurable delay between attempts.
-	Runs until explicitly stopped.
-	
-	Args:
-	    connector (Transport): Transport instance to manage connections for
-	    connect_delay (int, optional): Seconds between attempts. Defaults to 5.
-	
-	Attributes:
-	    running (bool): Whether thread should continue running
-	    connector (Transport): Transport to manage connections for
-	    connect_delay (int): Seconds to wait between connection attempts
-	"""
-	running: bool
-	connector: Transport
-	reconnectDelay: int
+    """Background thread that manages connection attempts.
 
-	def __init__(self, connector: Transport, reconnectDelay: int = 5) -> None:
-		super().__init__()
-		self.reconnectDelay = reconnectDelay
-		self.running = True
-		self.connector = connector
-		self.name = self.name + "_connector_loop"
-		self.daemon = True
+    Handles automatic reconnection with configurable delay between attempts.
+    Runs until explicitly stopped.
 
-	def run(self):
-		while self.running:
-			try:
-				self.connector.run()
-			except socket.error:
-				time.sleep(self.reconnectDelay)
-				continue
-			else:
-				time.sleep(self.reconnectDelay)
-		log.info("Ending control connector thread %s" % self.name)
+    Args:
+        connector (Transport): Transport instance to manage connections for
+        connect_delay (int, optional): Seconds between attempts. Defaults to 5.
+
+    Attributes:
+        running (bool): Whether thread should continue running
+        connector (Transport): Transport to manage connections for
+        connect_delay (int): Seconds to wait between connection attempts
+    """
+
+    running: bool
+    connector: Transport
+    reconnectDelay: int
+
+    def __init__(self, connector: Transport, reconnectDelay: int = 5) -> None:
+        super().__init__()
+        self.reconnectDelay = reconnectDelay
+        self.running = True
+        self.connector = connector
+        self.name = self.name + "_connector_loop"
+        self.daemon = True
+
+    def run(self):
+        while self.running:
+            try:
+                self.connector.run()
+            except socket.error:
+                time.sleep(self.reconnectDelay)
+                continue
+            else:
+                time.sleep(self.reconnectDelay)
+        log.info("Ending control connector thread %s" % self.name)
+
 
 def clear_queue(queue: Queue[Optional[bytes]]) -> None:
-	"""Empty all items from a queue without blocking.
-	
-	Removes all items from the queue in a non-blocking way,
-	useful for cleaning up before disconnection.
-	
-	Args:
-	    queue (Queue[Optional[bytes]]): Queue instance to clear
-	
-	Note:
-	    This function catches and ignores any exceptions that occur
-	    while trying to get items from an empty queue.
-	"""
-	try:
-		while True:
-			queue.get_nowait()
-	except Exception:
-		pass
+    """Empty all items from a queue without blocking.
+
+    Removes all items from the queue in a non-blocking way,
+    useful for cleaning up before disconnection.
+
+    Args:
+        queue (Queue[Optional[bytes]]): Queue instance to clear
+
+    Note:
+        This function catches and ignores any exceptions that occur
+        while trying to get items from an empty queue.
+    """
+    try:
+        while True:
+            queue.get_nowait()
+    except Exception:
+        pass

--- a/addon/globalPlugins/remoteClient/transport.py
+++ b/addon/globalPlugins/remoteClient/transport.py
@@ -1,3 +1,24 @@
+"""Network transport layer for NVDA Remote.
+
+This module provides the core networking functionality for NVDA Remote.
+
+Classes:
+    Transport: Base class defining the transport interface
+    TCPTransport: Implementation of secure TCP socket transport  
+    RelayTransport: Extended TCP transport for relay server connections
+    ConnectorThread: Helper class for connection management
+
+The transport layer handles:
+    * Secure socket connections with SSL/TLS
+    * Message serialization and deserialization 
+    * Connection management and reconnection
+    * Event notifications for connection state changes
+    * Message routing based on RemoteMessageType enum
+
+All network operations run in background threads, while message handlers
+are called on the main wxPython thread for thread-safety.
+"""
+
 import hashlib
 import select
 import socket
@@ -10,45 +31,180 @@ from queue import Queue
 from typing import Any, Callable, Dict, Optional, Tuple, Union
 from enum import Enum
 
-
+from extensionPoints import Action
+import wx
 
 log = getLogger('transport')
 
+
 from . import configuration
-from .callback_manager import CallbackManager
+from .serializer import Serializer
 from .socket_utils import SERVER_PORT, address_to_hostport, hostport_to_address
 from .protocol import RemoteMessageType, PROTOCOL_VERSION
 from .serializer import Serializer
 
-class TransportEvents(Enum):
-	CONNECTED = 'transport_connected'
-	CERTIFICATE_AUTHENTICATION_FAILED = 'certificate_authentication_failed'
-	CONNECTION_FAILED = 'transport_connection_failed'
-	CLOSING = 'transport_closing'
-	DISCONNECTED = 'transport_disconnected'
-
 
 class Transport:
+	"""Base class defining the network transport interface for NVDA Remote.
+	
+	This abstract base class defines the interface that all network transports must implement.
+	It provides core functionality for secure message passing, connection management,
+	and event handling between NVDA instances.
+	
+	The Transport class handles:
+	
+	* Message serialization and routing using a pluggable serializer
+	* Connection state management and event notifications
+	* Registration of message type handlers
+	* Thread-safe connection events
+	
+	To implement a new transport:
+	
+	1. Subclass Transport
+	2. Implement connection logic in run()
+	3. Call onTransportConnected() when connected
+	4. Use send() to transmit messages
+	5. Call appropriate event notifications
+	
+	Example:
+	    >>> serializer = JSONSerializer()
+	    >>> transport = TCPTransport(serializer, ("localhost", 8090))
+	    >>> transport.registerInbound(RemoteMessageType.key, handle_key)
+	    >>> transport.run()
+	
+	Args:
+	    serializer: The serializer instance to use for message encoding/decoding
+	
+	Attributes:
+	    connected (bool): True if transport has an active connection
+	    successful_connects (int): Counter of successful connection attempts
+	    connected_event (threading.Event): Event that is set when connected
+	    serializer (Serializer): The message serializer instance
+	    inboundHandlers (Dict[RemoteMessageType, Callable]): Registered message handlers
+	
+	Events:
+	    transportConnected: Fired after connection is established and ready
+	    transportDisconnected: Fired when existing connection is lost
+	    transportCertificateAuthenticationFailed: Fired when SSL certificate validation fails
+	    transportConnectionFailed: Fired when a connection attempt fails
+	    transportClosing: Fired before transport is shut down
+	"""
 	connected: bool
 	successful_connects: int
-	callback_manager: CallbackManager
-	connected_event: threading.Event
+	connected_event: threading.Event 
 	serializer: Serializer
 
-	def __init__(self, serializer: Any) -> None:
+
+
+	def __init__(self, serializer: Serializer) -> None:
 		self.serializer = serializer
-		self.callback_manager = CallbackManager()
 		self.connected = False
 		self.successful_connects = 0
-		self.connected_event = threading.Event()
+		self.connectedEvent = threading.Event()
+		# iterate over all the message types and create a dictionary of handlers mapping to Action()
+		self.inboundHandlers: Dict[RemoteMessageType, Callable] = {msg: Action() for msg in RemoteMessageType}
+		self.transportConnected = Action()
+		"""
+		Notifies when the transport is connected
+		"""
+		self.transportDisconnected = Action()
+		"""
+		Notifies when the transport is disconnected
+		"""
+		self.transportCertificateAuthenticationFailed = Action()
+		"""
+		Notifies when the transport fails to authenticate the certificate
+		"""
+		self.transportConnectionFailed = Action()
+		"""
+		Notifies when the transport fails to connect
+		"""
+		self.transportClosing = Action()
+		"""
+		Notifies when the transport is closing
+		"""
 
-	def transport_connected(self) -> None:
+	def onTransportConnected(self) -> None:
+		"""Handle successful transport connection.
+
+		Called internally when a connection is established. Updates connection state,
+		increments successful connection counter, and notifies listeners.
+
+		This method:
+		1. Increments successful connection counter
+		2. Sets connected flag to True
+		3. Sets the connected event
+		4. Notifies transportConnected listeners
+		"""
 		self.successful_connects += 1
 		self.connected = True
-		self.connected_event.set()
-		self.callback_manager.callCallbacks(TransportEvents.CONNECTED)
+		self.connectedEvent.set()
+		self.transportConnected.notify()
+
+	def registerInbound(self, type: RemoteMessageType, handler: Callable) -> None:
+		"""Register a handler for incoming messages of a specific type.
+
+		Adds a callback function to handle messages of the specified RemoteMessageType.
+		Multiple handlers can be registered for the same message type.
+
+		Args:
+			type (RemoteMessageType): The message type to handle
+			handler (Callable): Callback function to process messages of this type.
+				Will be called with the message payload as kwargs.
+
+		Example:
+			>>> def handle_keypress(key_code, pressed):
+			...     print(f"Key {key_code} {'pressed' if pressed else 'released'}")
+			>>> transport.registerInbound(RemoteMessageType.key_press, handle_keypress)
+
+		Note:
+			Handlers are called asynchronously on the wx main thread via wx.CallAfter
+		"""
+		self.inboundHandlers[type].register(handler)
+
+	def unregisterInbound(self, type: RemoteMessageType, handler: Callable) -> None:
+		"""Remove a previously registered message handler.
+
+		Removes a specific handler function from the list of handlers for a message type.
+		If the handler was not previously registered, this is a no-op.
+
+		Args:
+			type (RemoteMessageType): The message type to unregister from
+			handler (Callable): The handler function to remove
+
+		Example:
+			>>> transport.unregisterInbound(RemoteMessageType.key_press, handle_keypress)
+			
+		Note:
+			Must pass the exact same handler function that was previously registered
+		"""
+		self.inboundHandlers[type].unregister(handler)
 
 class TCPTransport(Transport):
+	"""Secure TCP socket transport implementation.
+	
+	This class implements the Transport interface using TCP sockets with SSL/TLS
+	encryption. It handles connection establishment, data transfer, and connection
+	lifecycle management.
+	
+	Args:
+	    serializer (Serializer): Message serializer instance
+	    address (Tuple[str, int]): Remote address to connect to
+	    timeout (int, optional): Connection timeout in seconds. Defaults to 0.
+	    insecure (bool, optional): Skip certificate verification. Defaults to False.
+	
+	Attributes:
+	    buffer (bytes): Buffer for incomplete received data
+	    closed (bool): Whether transport is closed
+	    queue (Queue[Optional[bytes]]): Queue of outbound messages
+	    insecure (bool): Whether to skip certificate verification
+	    address (Tuple[str, int]): Remote address to connect to
+	    timeout (int): Connection timeout in seconds
+	    server_sock (Optional[ssl.SSLSocket]): The SSL socket connection
+	    server_sock_lock (threading.Lock): Lock for thread-safe socket access
+	    queue_thread (Optional[threading.Thread]): Thread handling outbound messages
+	    reconnector_thread (ConnectorThread): Thread managing reconnection
+	"""
 	buffer: bytes
 	closed: bool
 	queue: Queue[Optional[bytes]]
@@ -97,12 +253,12 @@ class TCPTransport(Transport):
 				self.insecure=True
 				return self.run()
 			self.last_fail_fingerprint = fingerprint
-			self.callback_manager.callCallbacks(TransportEvents.CERTIFICATE_AUTHENTICATION_FAILED)
+			self.transportCertificateAuthenticationFailed.notify()
 			raise
 		except Exception:
-			self.callback_manager.callCallbacks(TransportEvents.CONNECTION_FAILED)
+			self.transportConnectionFailed.notify()
 			raise
-		self.transport_connected()
+		self.onTransportConnected()
 		self.queue_thread = threading.Thread(target=self.send_queue)
 		self.queue_thread.daemon = True
 		self.queue_thread.start()
@@ -122,11 +278,27 @@ class TCPTransport(Transport):
 					self.buffer = b''
 					break
 		self.connected = False
-		self.connected_event.clear()
-		self.callback_manager.callCallbacks(TransportEvents.DISCONNECTED)
+		self.connectedEvent.clear()
+		self.transportDisconnected.notify()
 		self._disconnect()
 
 	def create_outbound_socket(self, host: str, port: int, insecure: bool = False) -> ssl.SSLSocket:
+		"""Create and configure an SSL socket for outbound connections.
+
+		Creates a TCP socket with appropriate timeout and keep-alive settings,
+		then wraps it with SSL/TLS encryption.
+
+		Args:
+			host (str): Remote hostname to connect to
+			port (int): Remote port number
+			insecure (bool, optional): Skip certificate verification. Defaults to False.
+
+		Returns:
+			ssl.SSLSocket: Configured SSL socket ready for connection
+
+		Note:
+			The socket is created but not yet connected. Call connect() separately.
+		"""
 		address = socket.getaddrinfo(host, port)[0]
 		server_sock = socket.socket(*address[:3])
 		if self.timeout:
@@ -141,10 +313,34 @@ class TCPTransport(Transport):
 		return server_sock
 
 	def getpeercert(self, binary_form: bool = False) -> Optional[Union[Dict[str, Any], bytes]]:
+		"""Get the certificate from the peer.
+
+		Retrieves the certificate presented by the remote peer during SSL handshake.
+
+		Args:
+			binary_form (bool, optional): If True, return the raw certificate bytes.
+				If False, return a parsed dictionary. Defaults to False.
+
+		Returns:
+			Optional[Union[Dict[str, Any], bytes]]: The peer's certificate, or None if not connected.
+				Format depends on binary_form parameter.
+		"""
 		if self.server_sock is None: return None
 		return self.server_sock.getpeercert(binary_form)
 
 	def handle_server_data(self) -> None:
+		"""Process incoming data from the server socket.
+
+		Reads available data from the socket, buffers partial messages,
+		and processes complete messages by passing them to parse().
+
+		Messages are expected to be newline-delimited.
+		Partial messages are stored in self.buffer until complete.
+
+		Note:
+			This method handles SSL-specific socket behavior and non-blocking reads.
+			It is called when select() indicates data is available.
+		"""
 		# This approach may be problematic:
 		# See also server.py handle_data in class Client.
 		buffSize = 16384
@@ -178,14 +374,44 @@ class TCPTransport(Transport):
 		self.buffer += data
 
 	def parse(self, line: bytes) -> None:
+		"""Parse and handle a complete message line.
+
+		Deserializes a message and routes it to the appropriate handler based on type.
+
+		Args:
+			line (bytes): Complete message line to parse
+
+		Note:
+			Messages must include a 'type' field matching a RemoteMessageType enum value.
+			Handler callbacks are executed asynchronously on the wx main thread.
+			Invalid or unhandled message types are logged as errors.
+		"""
 		obj = self.serializer.deserialize(line)
 		if 'type' not in obj:
+			log.error("Received message without type: %r" % obj)
 			return
-		callback = "msg_"+obj['type']
+		try:
+			messageType = RemoteMessageType(obj['type'])
+		except ValueError:
+			log.error("Received message with invalid type: %r" % obj)
+			return
 		del obj['type']
-		self.callback_manager.callCallbacks(callback, **obj)
+		extensionPoint = self.inboundHandlers.get(messageType)
+		if not extensionPoint:
+			log.error("Received message with unhandled type: %r" % obj)
+			return
+		wx.CallAfter(extensionPoint.notify, **obj)
 
 	def send_queue(self) -> None:
+		"""Background thread that processes the outbound message queue.
+
+		Continuously pulls messages from the queue and sends them over the socket.
+		Thread exits when None is received from the queue or a socket error occurs.
+
+		Note:
+			This method runs in a separate thread and handles thread-safe socket access
+			using the server_sock_lock.
+		"""
 		while True:
 			item = self.queue.get()
 			if item is None:
@@ -197,11 +423,33 @@ class TCPTransport(Transport):
 				return
 
 	def send(self, type: str|Enum, **kwargs: Any) -> None:
+		"""Send a message through the transport.
+
+		Serializes and queues a message for transmission. Messages are sent
+		asynchronously by the queue thread.
+
+		Args:
+			type (str|Enum): Message type, typically a RemoteMessageType enum value
+			**kwargs: Message payload data to serialize
+
+		Note:
+			This method is thread-safe and can be called from any thread.
+			If the transport is not connected, the message will be silently dropped.
+		"""
 		obj = self.serializer.serialize(type=type, **kwargs)
 		if self.connected:
 			self.queue.put(obj)
 
-	def _disconnect(self):
+	def _disconnect(self) -> None:
+		"""Internal method to disconnect the transport.
+
+		Cleans up the send queue thread, empties queued messages,
+		and closes the socket connection.
+
+		Note:
+			This is called internally on errors, unlike close() which is called
+			explicitly to shut down the transport.
+		"""
 		"""Disconnect the transport due to an error, without closing the connector thread."""
 		if self.queue_thread is not None:
 			self.queue.put(None)
@@ -213,20 +461,40 @@ class TCPTransport(Transport):
 			self.server_sock = None
 
 	def close(self):
-		self.callback_manager.callCallbacks(TransportEvents.CLOSING)
+		"""Close the transport."""
+		self.transportClosing.notify()
 		self.reconnector_thread.running = False
 		self._disconnect()
 		self.closed = True
 		self.reconnector_thread = ConnectorThread(self)
 
 class RelayTransport(TCPTransport):
+	"""Transport for connecting through a relay server.
+	
+	Extends TCPTransport with relay-specific protocol handling for channels
+	and connection types. Manages protocol versioning and channel joining.
+	
+	Args:
+	    serializer (Serializer): Message serializer instance
+	    address (Tuple[str, int]): Relay server address
+	    timeout (int, optional): Connection timeout. Defaults to 0.
+	    channel (Optional[str], optional): Channel to join. Defaults to None.
+	    connection_type (Optional[str], optional): Connection type. Defaults to None.
+	    protocol_version (int, optional): Protocol version. Defaults to PROTOCOL_VERSION.
+	    insecure (bool, optional): Skip certificate verification. Defaults to False.
+	
+	Attributes:
+	    channel (Optional[str]): Relay channel name
+	    connection_type (Optional[str]): Type of relay connection
+	    protocol_version (int): Protocol version to use
+	"""
 	channel: Optional[str]
 	connection_type: Optional[str]
 	protocol_version: int
 
 	def __init__(
 		self,
-		serializer: Any,
+		serializer: Serializer,
 		address: Tuple[str, int],
 		timeout: int = 0,
 		channel: Optional[str] = None,
@@ -239,16 +507,33 @@ class RelayTransport(TCPTransport):
 		self.channel = channel
 		self.connection_type = connection_type
 		self.protocol_version = protocol_version
-		self.callback_manager.registerCallback(TransportEvents.CONNECTED, self.on_connected)
+		self.transportConnected.register(self.onConnected)
 
-	def on_connected(self) -> None:
+
+
+	def onConnected(self) -> None:
 		self.send(RemoteMessageType.protocol_version, version=self.protocol_version)
+
 		if self.channel is not None:
 			self.send(RemoteMessageType.join, channel=self.channel, connection_type=self.connection_type)
 		else:
 			self.send(RemoteMessageType.generate_key)
 
 class ConnectorThread(threading.Thread):
+	"""Background thread that manages connection attempts.
+	
+	Handles automatic reconnection with configurable delay between attempts.
+	Runs until explicitly stopped.
+	
+	Args:
+	    connector (Transport): Transport instance to manage connections for
+	    connect_delay (int, optional): Seconds between attempts. Defaults to 5.
+	
+	Attributes:
+	    running (bool): Whether thread should continue running
+	    connector (Transport): Transport to manage connections for
+	    connect_delay (int): Seconds to wait between connection attempts
+	"""
 	running: bool
 	connector: Transport
 	connect_delay: int
@@ -273,6 +558,18 @@ class ConnectorThread(threading.Thread):
 		log.info("Ending control connector thread %s" % self.name)
 
 def clear_queue(queue: Queue[Optional[bytes]]) -> None:
+	"""Empty all items from a queue without blocking.
+	
+	Removes all items from the queue in a non-blocking way,
+	useful for cleaning up before disconnection.
+	
+	Args:
+	    queue (Queue[Optional[bytes]]): Queue instance to clear
+	
+	Note:
+	    This function catches and ignores any exceptions that occur
+	    while trying to get items from an empty queue.
+	"""
 	try:
 		while True:
 			queue.get_nowait()

--- a/addon/globalPlugins/remoteClient/transport.py
+++ b/addon/globalPlugins/remoteClient/transport.py
@@ -509,10 +509,8 @@ class RelayTransport(TCPTransport):
 		self.transportConnected.register(self.onConnected)
 
 
-
 	def onConnected(self) -> None:
 		self.send(RemoteMessageType.protocol_version, version=self.protocol_version)
-
 		if self.channel is not None:
 			self.send(RemoteMessageType.join, channel=self.channel, connection_type=self.connection_type)
 		else:

--- a/addon/globalPlugins/remoteClient/url_handler.py
+++ b/addon/globalPlugins/remoteClient/url_handler.py
@@ -50,7 +50,7 @@ class URLHandlerWindow(windowUtils.CustomWindow):
 		url = ctypes.wstring_at(message_data.contents.lpData)
 		log.info("Received url: %s" % url)
 		try:
-			con_info = connection_info.ConnectionInfo.from_url(url)
+			con_info = connection_info.ConnectionInfo.fromURL(url)
 		except connection_info.URLParsingError:
 			wx.CallLater(50, gui.messageBox, parent=gui.mainFrame, caption=_("Invalid URL"),
 						 # Translators: Message shown when an invalid URL has been provided.


### PR DESCRIPTION
What works
* configspec is copied to config.conf.spec['Remote']
* current remote.ini configuration is copied to config.conf['Remote']
* Settings panel loads and saves to and from NVDA's config manager

Changes to how NVDARemote uses the configuration.py file
* Configuration.save_config should be called instead of configuration.get_config().write
* Configuration.get_conf returns nvda's config.conf['Remote'] section instead of the old root configobj

Problems/todo
* Sometimes NVDA says the configuration is corrupted
* Something may be causing sections of 'remote' to appear at the root level of config.conf
* Todo: separate the logic for upgrading to config manager from setting config manager's confspec.
* Todo: replace all config.write with configuration.save_config
