### PR TITLE
config migration

### DIFF
--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -310,7 +310,7 @@ class GlobalPlugin(_GlobalPlugin):
 			if a == wx.ID_YES:
 				config = configuration.get_config()
 				config['trusted_certs'][hostPortToAddress(self.lastFailAddress)]=certHash
-				config.write()
+				configuration.save_config()
 			if a == wx.ID_YES or a == wx.ID_NO: return True
 		except Exception as ex:
 			log.error(ex)

--- a/addon/globalPlugins/remoteClient/configuration.py
+++ b/addon/globalPlugins/remoteClient/configuration.py
@@ -13,30 +13,8 @@ nvdaConf.BASE_ONLY_SECTIONS.add(configRoot)
 CONFIG_FILE_NAME = 'remote.ini'
 
 _config = None
-configspec2 = {
-	'connections': {
-		'last_connected': 'list(default=list())'
-	}, 
-	'controlserver': {
-		'autoconnect': 'boolean(default=False)',
-		'self_hosted': 'boolean(default=False)',
-		'connection_type': 'integer(default=0)', 
-		'host': 'string(default="")', 
-		'port': 'integer(default=6837)', 
-		'key': 'string(default="")'
-	},
-	'seen_motds': {
-		'__many__': 'string(default="")'
-	}, 
-	'trusted_certs': {
-		'__many__': 'string(default="")'
-	}, 
-	'ui': {
-		'play_sounds': 'boolean(default=True)'
-	}
-}
 
-configspec = StringIO("""
+spec = StringIO("""
 [connections]
 	last_connected = list(default=list())
 [controlserver]
@@ -57,19 +35,22 @@ configspec = StringIO("""
 	play_sounds = boolean(default=True)
 """)
 
+configspec = configobj.ConfigObj(spec)
 
 def get_config():
 	global _config
 	if not _config:
 		# Save the config spec to NVDA's config
-		nvdaConf.spec[configRoot] = configspec2
 		path = os.path.abspath(os.path.join(globalVars.appArgs.configPath, CONFIG_FILE_NAME))
 		if os.path.exists(path):
 			_config = configobj.ConfigObj(infile=path, configspec=configspec, create_empty=True)
-			val = validate.Validator()
-			_config.validate(val, copy=True)
-			nvdaConf[configRoot] = _config.dict()
 			os.remove(path)
+		else:
+			_config = configobj.ConfigObj(configspec=configspec)
+		val = validate.Validator()
+		_config.validate(val, copy=True)
+		nvdaConf.spec[configRoot] = _config.configspec.copy()
+		nvdaConf[configRoot] = _config.dict()
 		save_config()
 	_config = nvdaConf[configRoot]
 	return _config

--- a/addon/globalPlugins/remoteClient/configuration.py
+++ b/addon/globalPlugins/remoteClient/configuration.py
@@ -9,12 +9,12 @@ from . import socket_utils
 
 configRoot = "Remote"
 # Ensure this config is only in base sections, not sub profiles
-nvdaConf.BASE_ONLY_SECTIONS.add(configRoot)
+#nvdaConf.BASE_ONLY_SECTIONS.add(configRoot)
 CONFIG_FILE_NAME = 'remote.ini'
 
 _config = None
 
-spec = StringIO("""
+configspec = StringIO("""
 [connections]
 	last_connected = list(default=list())
 [controlserver]
@@ -35,23 +35,21 @@ spec = StringIO("""
 	play_sounds = boolean(default=True)
 """)
 
-configspec = configobj.ConfigObj(spec)
-
 def get_config():
 	global _config
 	if not _config:
-		# Save the config spec to NVDA's config
 		path = os.path.abspath(os.path.join(globalVars.appArgs.configPath, CONFIG_FILE_NAME))
-		if os.path.exists(path):
-			_config = configobj.ConfigObj(infile=path, configspec=configspec, create_empty=True)
+		if os.path.isfile(path):
+			_config = configobj.ConfigObj(infile=path, configspec=configspec)
+			nvdaConf.spec[configRoot] = _config.configspec.dict()
+			save_config()
+			nvdaConf[configRoot] = _config.dict()
+			save_config()
 			os.remove(path)
 		else:
 			_config = configobj.ConfigObj(configspec=configspec)
-		val = validate.Validator()
-		_config.validate(val, copy=True)
-		nvdaConf.spec[configRoot] = _config.configspec.copy()
-		nvdaConf[configRoot] = _config.dict()
-		save_config()
+			nvdaConf.spec[configRoot] = _config.configspec.dict()
+			save_config()
 	_config = nvdaConf[configRoot]
 	return _config
 

--- a/addon/globalPlugins/remoteClient/configuration.py
+++ b/addon/globalPlugins/remoteClient/configuration.py
@@ -4,12 +4,38 @@ from io import StringIO
 import configobj
 import globalVars
 from configobj import validate
-
+from config import conf as nvdaConf
 from . import socket_utils
 
+configRoot = "Remote"
+# Ensure this config is only in base sections, not sub profiles
+nvdaConf.BASE_ONLY_SECTIONS.add(configRoot)
 CONFIG_FILE_NAME = 'remote.ini'
 
 _config = None
+configspec2 = {
+	'connections': {
+		'last_connected': 'list(default=list())'
+	}, 
+	'controlserver': {
+		'autoconnect': 'boolean(default=False)',
+		'self_hosted': 'boolean(default=False)',
+		'connection_type': 'integer(default=0)', 
+		'host': 'string(default="")', 
+		'port': 'integer(default=6837)', 
+		'key': 'string(default="")'
+	},
+	'seen_motds': {
+		'__many__': 'string(default="")'
+	}, 
+	'trusted_certs': {
+		'__many__': 'string(default="")'
+	}, 
+	'ui': {
+		'play_sounds': 'boolean(default=True)'
+	}
+}
+
 configspec = StringIO("""
 [connections]
 	last_connected = list(default=list())
@@ -30,14 +56,27 @@ configspec = StringIO("""
 [ui]
 	play_sounds = boolean(default=True)
 """)
+
+
 def get_config():
 	global _config
 	if not _config:
+		# Save the config spec to NVDA's config
+		nvdaConf.spec[configRoot] = configspec2
 		path = os.path.abspath(os.path.join(globalVars.appArgs.configPath, CONFIG_FILE_NAME))
-		_config = configobj.ConfigObj(infile=path, configspec=configspec, create_empty=True)
-		val = validate.Validator()
-		_config.validate(val, copy=True)
+		if os.path.exists(path):
+			_config = configobj.ConfigObj(infile=path, configspec=configspec, create_empty=True)
+			val = validate.Validator()
+			_config.validate(val, copy=True)
+			nvdaConf[configRoot] = _config.dict()
+			os.remove(path)
+		save_config()
+	_config = nvdaConf[configRoot]
 	return _config
+
+def save_config():
+	nvdaConf.save()
+	return True
 
 def write_connection_to_config(address):
 	"""Writes an address to the last connected section of the config.
@@ -48,4 +87,4 @@ def write_connection_to_config(address):
 	if address in last_cons:
 		conf['connections']['last_connected'].remove(address)
 	conf['connections']['last_connected'].append(address)
-	conf.write()
+	save_config()

--- a/addon/globalPlugins/remoteClient/dialogs.py
+++ b/addon/globalPlugins/remoteClient/dialogs.py
@@ -80,7 +80,7 @@ class ClientPanel(wx.Panel):
 			if a == wx.ID_YES:
 				config = configuration.get_config()
 				config['trusted_certs'][self.host.GetValue()]=cert_hash
-				config.write()
+				configuration.save_config()
 			if a != wx.ID_YES and a != wx.ID_NO: return
 		except Exception as ex:
 			log.error(ex)

--- a/addon/globalPlugins/remoteClient/session.py
+++ b/addon/globalPlugins/remoteClient/session.py
@@ -83,7 +83,7 @@ Please either use a different server or upgrade your version of the addon.""")
 		if current == hashed:
 			return False
 		conf['seen_motds'][address] = hashed
-		conf.write()
+		configuration.save_config()
 		return True
 
 	def handleClientConnected(self, client: Optional[Dict[str, Any]] = None) -> None:

--- a/addon/globalPlugins/remoteClient/settings_panel.py
+++ b/addon/globalPlugins/remoteClient/settings_panel.py
@@ -84,7 +84,7 @@ class RemoteSettingsPanel(SettingsPanel):
 	def on_delete_fingerprints(self, evt: wx.CommandEvent) -> None:
 		if gui.messageBox(_("When connecting to an unauthorized server, you will again be prompted to accepts its certificate."), _("Are you sure you want to delete all stored trusted fingerprints?"), wx.YES|wx.NO|wx.NO_DEFAULT|wx.ICON_WARNING) == wx.YES:
 			self.config['trusted_certs'].clear()
-			self.config.write()
+			configuration.save_config()
 		evt.Skip()
 
 	def isValid(self) -> bool:
@@ -110,7 +110,7 @@ class RemoteSettingsPanel(SettingsPanel):
 			cs['port'] = int(self.port.GetValue())
 		cs['key'] = self.key.GetValue()
 		self.config['ui']['play_sounds'] = self.play_sounds.GetValue()
-		self.config.write()
+		configuration.save_config()
 
 	def onSave(self):
 		self.write_to_config()


### PR DESCRIPTION
- **Refactor Remote Client Configuration to Use NVDA's Configuration Manager**
- **Fix: Doesn't corrupt NVDA.ini and does not convert types to string.**
- **Update settings panel to save to config manager**
- **Fix: converting to nvda's config manager works properly now. Configspecs are loaded, existing remote.ini is loaded if exists, then deleted.**
- **Refactor: change conf.write to configuration.save_config**
