### PR TITLE
Split Client

### DIFF
--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -1,6 +1,5 @@
 import logging
 import sys
-from typing import Tuple
 
 import addonHandler
 import ui
@@ -27,6 +26,7 @@ class GlobalPlugin(_GlobalPlugin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.client = RemoteClient()
+        self.client.registerLocalScript(self.script_sendKeys)
 
     def terminate(self):
         self.client.terminate()

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -1,428 +1,75 @@
-import ctypes
-import ctypes.wintypes
 import logging
-import os
 import sys
-import threading
-from typing import Callable, Optional, Set, Tuple
+from typing import Tuple
 
 import addonHandler
-import api
-import braille
-import configobj
-import core
-import globalVars
-import gui
-import queueHandler
-import speech
 import ui
-import wx
-from config import isInstalledCopy
 from globalPluginHandler import GlobalPlugin as _GlobalPlugin
-from keyboardHandler import KeyboardInputGesture
-from scriptHandler import script
-from utils.security import isRunningOnSecureDesktop
-
-from . import configuration, cues, local_machine, serializer, url_handler
-from .alwaysCallAfter import alwaysCallAfter
-from .connection_info import ConnectionInfo, ConnectionMode
-from .menu import RemoteMenu
-from .protocol import RemoteMessageType
-from .secureDesktop import SecureDesktopHandler
-from .session import MasterSession, SlaveSession
-from .settings_panel import RemoteSettingsPanel
-from .transport import RelayTransport
 from logHandler import log
-try:
-	addonHandler.initTranslation()
-except addonHandler.AddonError:
-	log.warning(
-		"Unable to initialise translations. This may be because the addon is running from NVDA scratchpad."
-	)
-from winUser import WM_QUIT  # provided by NVDA
+from scriptHandler import script
 
-from . import dialogs, keyboard_hook, server
-from .socket_utils import addressToHostPort, hostPortToAddress
+from .client import RemoteClient
+
+try:
+    addonHandler.initTranslation()
+except addonHandler.AddonError:
+    log.warning(
+        "Unable to initialise translations. This may be because the addon is running from NVDA scratchpad."
+    )
+
 
 logging.getLogger("keyboard_hook").addHandler(logging.StreamHandler(sys.stdout))
 
-# Type aliases
-KeyModifier = Tuple[int, bool]  # (vk_code, extended)
-Address = Tuple[str, int]  # (hostname, port) 
-
-
-
 class GlobalPlugin(_GlobalPlugin):
-	scriptCategory: str = _("NVDA Remote")
-	localScripts: Set[Callable]
-	localMachine: local_machine.LocalMachine
-	masterSession: Optional[MasterSession] 
-	slaveSession: Optional[SlaveSession]
-	keyModifiers: Set[KeyModifier]
-	hostPendingModifiers: Set[KeyModifier]
-	connecting: bool
-	masterTransport: Optional[RelayTransport]
-	slaveTransport: Optional[RelayTransport]
-	localControlServer: Optional[server.LocalRelayServer]
-	hookThread: Optional[threading.Thread]
-	sendingKeys: bool
+    scriptCategory: str = _("NVDA Remote")
+    client: RemoteClient
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.client = RemoteClient()
 
-	def __init__(self, *args, **kwargs):
-		super().__init__(*args, **kwargs)
-		self.keyModifiers = set()
-		self.hostPendingModifiers = set()
-		self.localScripts = {self.script_sendKeys}
-		self.localMachine = local_machine.LocalMachine()
-		self.slaveSession = None
-		self.masterSession = None
-		self.menu: RemoteMenu = RemoteMenu(self)
-		self.connecting = False
-		self.URLHandlerWindow = url_handler.URLHandlerWindow(callback=self.verifyAndConnect)
-		url_handler.register_url_handler()
-		self.masterTransport = None
-		self.slaveTransport = None
-		self.localControlServer = None
-		self.hookThread = None
-		self.sendingKeys = False
-		try:
-			configuration.get_config()
-		except configobj.ParseError:
-			os.remove(os.path.abspath(os.path.join(globalVars.appArgs.configPath, configuration.CONFIG_FILE_NAME)))
-			queueHandler.queueFunction(queueHandler.eventQueue, wx.CallAfter, wx.MessageBox, _("Your NVDA Remote configuration was corrupted and has been reset."), _("NVDA Remote Configuration Error"), wx.OK|wx.ICON_EXCLAMATION)
-		if not globalVars.appArgs.secure:
-			gui.settingsDialogs.NVDASettingsDialog.categoryClasses.append(RemoteSettingsPanel)
-		self.sdHandler = SecureDesktopHandler()
-		if isRunningOnSecureDesktop():
-			connection = self.sdHandler.initializeSecureDesktop()
-			if connection:
-				self.connectAsSlave(connection.address, connection.channel, insecure=True)
-				self.slaveSession.transport.connectedEvent.wait(self.sdHandler.SD_CONNECT_BLOCK_TIMEOUT)
-		core.postNvdaStartup.register(self.performAutoconnect)
+    def terminate(self):
+        self.client.terminate()
 
-	def performAutoconnect(self):
-		controlServerConfig = configuration.get_config()['controlserver']
-		if not controlServerConfig['autoconnect'] or self.masterSession or self.slaveSession:
-			log.debug("Autoconnect disabled or already connected")
-			return
-		key  = controlServerConfig['key']
-		if controlServerConfig['self_hosted']:
-			port = controlServerConfig['port']
-			hostname = 'localhost'
-			self.startControlServer(port, key )
-		else:
-			address = addressToHostPort(controlServerConfig['host'])
-			hostname, port = address
-		mode = ConnectionMode.SLAVE if controlServerConfig['connection_type']==0 else ConnectionMode.MASTER
-		conInfo = ConnectionInfo(mode=mode, hostname=hostname, port=port, key=key)
-		self.connect(conInfo)
+    @script(
+        description=_("""Mute or unmute the speech coming from the remote computer""")
+    )
+    def script_toggle_remote_mute(self, gesture):
+        self.client.toggleMute()
 
-	def terminate(self):
-		self.sdHandler.terminate()
-		self.disconnect()
-		self.localMachine.terminate()
-		self.localMachine = None
-		self.menu.terminate()
-		self.menu=None
-		if not isInstalledCopy():
-			url_handler.unregister_url_handler()
-		self.URLHandlerWindow.destroy()
-		self.URLHandlerWindow=None
-		if not globalVars.appArgs.secure:
-			gui.settingsDialogs.NVDASettingsDialog.categoryClasses.remove(RemoteSettingsPanel)
+    @script(
+        gesture="kb:control+shift+NVDA+c",
+        description=_("Sends the contents of the clipboard to the remote machine"),
+    )
+    def script_push_clipboard(self, gesture):
+        self.client.pushClipboard()
 
+    @script(description=_("""Copies a link to the remote session to the clipboard"""))
+    def script_copy_link(self, gesture):
+        self.client.copyLink()
+        ui.message(_("Copied link"))
 
-	def toggleMute(self):
-		self.localMachine.isMuted = self.menu.muteItem.IsChecked()
+    @script(
+        gesture="kb:alt+NVDA+pageDown", description=_("""Disconnect a remote session""")
+    )
+    def script_disconnect(self, gesture):
+        if not self.client.isConnected:
+            ui.message(_("Not connected."))
+            return
+        self.client.disconnect()
 
-	@script(description=_("""Mute or unmute the speech coming from the remote computer"""))
-	def script_toggle_remote_mute(self, gesture):
-		if not self.isConnected() or self.connecting: return
-		self.localMachine.isMuted = not self.localMachine.isMuted
-		self.menu.muteItem.Check(self.localMachine.isMuted)
-		# Translators: Report when using gestures to mute or unmute the speech coming from the remote computer.
-		status = _("Mute speech and sounds from the remote computer") if self.localMachine.isMuted else _("Unmute speech and sounds from the remote computer")
-		ui.message(status)
+    @script(
+        gesture="kb:alt+NVDA+pageUp", description=_("""Connect to a remote computer""")
+    )
+    def script_connect(self, gesture):
+        if self.client.isConnected() or self.client.connecting:
+            return
+        self.client.doConnect()
 
-	def pushClipboard(self):
-		connector = self.slaveTransport or self.masterTransport
-		if not getattr(connector,'connected',False):
-			ui.message(_("Not connected."))
-			return
-		try:
-			connector.send(RemoteMessageType.set_clipboard_text, text=api.getClipData())
-			cues.clipboard_pushed()
-			ui.message(_("Clipboard pushed"))
-		except TypeError:
-			log.exception("Unable to push clipboard")
-
-	@script(gesture="kb:control+shift+NVDA+c", description=_("Sends the contents of the clipboard to the remote machine"))
-	def script_push_clipboard(self, gesture):
-		self.pushClipboard()
-
-	def copyLink(self):
-		session = self.masterSession or self.slaveSession
-		url = session.getConnectionInfo().getURLToConnect()
-		api.copyToClip(str(url))
-
-	@script(description=_("""Copies a link to the remote session to the clipboard"""))
-	def script_copy_link(self, gesture):
-		self.copyLink()
-		ui.message(_("Copied link"))
-
-	def sendSAS(self):
-		self.masterTransport.send(RemoteMessageType.send_SAS)
-
-	def connect(self, connectionInfo: ConnectionInfo, insecure=False):
-		if connectionInfo.mode == ConnectionMode.MASTER:
-			self.connectAsMaster((connectionInfo.hostname, connectionInfo.port), connectionInfo.key, insecure)
-		elif connectionInfo.mode == ConnectionMode.SLAVE:
-			self.connectAsSlave((connectionInfo.hostname, connectionInfo.port), connectionInfo.key, insecure)
-
-	def disconnect(self):
-		if self.masterTransport is None and self.slaveTransport is None:
-			return
-		if self.localControlServer is not None:
-			self.localControlServer.close()
-			self.localControlServer = None
-		if self.masterTransport is not None:
-			self.disconnectAsMaster()
-		if self.slaveTransport is not None:
-			self.disconnectAsSlave()
-		cues.disconnected()
-		self.menu.handleConnected(False)
-
-	def disconnectAsMaster(self):
-		self.masterTransport.close()
-		self.masterTransport = None
-		self.masterSession = None
-
-	def disconnectingAsMaster(self):
-		if self.menu:
-			self.menu.handleConnected(False)
-		if self.localMachine:
-			self.localMachine.isMuted = False
-		self.sendingKeys = False
-		if self.hookThread is not None:
-			ctypes.windll.user32.PostThreadMessageW(self.hookThread.ident, WM_QUIT, 0, 0)
-			self.hookThread.join()
-			self.hookThread = None
-		self.keyModifiers = set()
-
-	def disconnectAsSlave(self):
-		self.slaveTransport.close()
-		self.slaveTransport = None
-		self.slaveSession = None
-		self.sdHandler.slaveSession = None
-
-	@alwaysCallAfter
-	def onConnectAsMasterFailed(self):
-		if self.masterTransport.successfulConnects == 0:
-			self.disconnectAsMaster()
-			# Translators: Title of the connection error dialog.
-			gui.messageBox(parent=gui.mainFrame, caption=_("Error Connecting"),
-			# Translators: Message shown when cannot connect to the remote computer.
-			message=_("Unable to connect to the remote computer"), style=wx.OK | wx.ICON_WARNING)
-
-	@script(gesture="kb:alt+NVDA+pageDown", description=_("""Disconnect a remote session"""))
-	def script_disconnect(self, gesture):
-		if not self.isConnected:
-			ui.message(_("Not connected."))
-			return
-		self.disconnect()
-
-	@script(gesture="kb:alt+NVDA+pageUp", description=_("""Connect to a remote computer"""))
-	def script_connect(self, gesture):
-		if self.isConnected() or self.connecting:
-			return
-		self.doConnect(evt = None)
-
-	def doConnect(self, evt=None):
-		if evt is not None:
-			evt.Skip()
-		previousConnections = configuration.get_config()['connections']['last_connected']
-		hostnames = list(reversed(previousConnections))
-		# Translators: Title of the connect dialog.
-		dlg = dialogs.DirectConnectDialog(parent=gui.mainFrame, id=wx.ID_ANY, title=_("Connect"), hostnames=hostnames)
-		
-		def handleDialogCompletion(dlgResult):
-			if dlgResult != wx.ID_OK:
-				return
-			connectionInfo = dlg.getConnectionInfo()
-			if dlg.client_or_server.GetSelection() == 1:  # server
-				self.startControlServer(connectionInfo.port, connectionInfo.key)
-			self.connect(connectionInfo=connectionInfo, insecure=dlg.client_or_server.GetSelection() == 1)
-		gui.runScriptModalDialog(dlg, callback=handleDialogCompletion)
-
-	def onConnectedAsMaster(self):
-		configuration.write_connection_to_config(self.masterTransport.address)
-		self.menu.handleConnected(True)
-		# We might have already created a hook thread before if we're restoring an
-		# interrupted connection. We must not create another.
-		if not self.hookThread:
-			self.hookThread = threading.Thread(target=self.hook)
-			self.hookThread.daemon = True
-			self.hookThread.start()
-		# Translators: Presented when connected to the remote computer.
-		ui.message(_("Connected!"))
-		cues.connected()
-
-	def onDisconnectedAsMaster(self):
-		# Translators: Presented when connection to a remote computer was interupted.
-		ui.message(_("Connection interrupted"))
-
-	def connectAsMaster(self, address, key, insecure=False):
-		transport = RelayTransport(address=address, serializer=serializer.JSONSerializer(), channel=key, connectionType='master', insecure=insecure)
-		self.masterSession = MasterSession(transport=transport, localMachine=self.localMachine)
-		transport.transportCertificateAuthenticationFailed.register(self.onMasterCertificateFailed)
-		transport.transportConnected.register(self.onConnectedAsMaster)
-		transport.transportConnectionFailed.register(self.onConnectAsMasterFailed)
-		transport.transportClosing.register(self.disconnectingAsMaster)
-		transport.transportDisconnected.register(self.onDisconnectedAsMaster)
-		transport.reconnectorThread.start()
-		self.masterTransport = transport
-
-	def connectAsSlave(self, address, key, insecure=False):
-		transport = RelayTransport(serializer=serializer.JSONSerializer(), address=address, channel=key, connectionType='slave', insecure=insecure)
-		self.slaveSession = SlaveSession(transport=transport, localMachine=self.localMachine)
-		self.sdHandler.slaveSession = self.slaveSession
-		self.slaveTransport = transport
-		transport.transportCertificateAuthenticationFailed.register(self.onSlaveCertificateFailed)
-		transport.transportConnected.register(self.onConnectedAsSlave)
-		transport.reconnectorThread.start()
-		self.menu.disconnectItem.Enable(True)
-		self.menu.connectItem.Enable(False)
-
-	def handleCertificateFailure(self, transport: RelayTransport):
-		self.lastFailAddress = transport.address
-		self.lastFailKey = transport.channel
-		self.disconnect()
-		try:
-			certHash = transport.lastFailFingerprint
-
-			wnd = dialogs.CertificateUnauthorizedDialog(None, fingerprint=certHash)
-			a = wnd.ShowModal()
-			if a == wx.ID_YES:
-				config = configuration.get_config()
-				config['trusted_certs'][hostPortToAddress(self.lastFailAddress)]=certHash
-				config.write()
-			if a == wx.ID_YES or a == wx.ID_NO: return True
-		except Exception as ex:
-			log.error(ex)
-		return False
-
-	@alwaysCallAfter
-	def onMasterCertificateFailed(self):
-		if self.handleCertificateFailure(self.masterTransport):
-			self.connectAsMaster(self.lastFailAddress, self.lastFailKey, True)
-
-	@alwaysCallAfter
-	def onSlaveCertificateFailed(self):
-		if self.handleCertificateFailure(self.slaveTransport):
-			self.connectAsSlave(self.lastFailAddress, self.lastFailKey, True)
-
-	@alwaysCallAfter
-	def onConnectedAsSlave(self):
-		log.info("Control connector connected")
-		cues.control_server_connected()
-		# Translators: Presented in direct (client to server) remote connection when the controlled computer is ready.
-		speech.speakMessage(_("Connected to control server"))
-		self.menu.pushClipboardItem.Enable(True)
-		self.menu.copyLinkItem.Enable(True)
-		configuration.write_connection_to_config(self.slaveTransport.address)
-
-	def startControlServer(self, serverPort, channel):
-		self.localControlServer = server.LocalRelayServer(serverPort, channel)
-		serverThread = threading.Thread(target=self.localControlServer.run)
-		serverThread.daemon = True
-		serverThread.start()
-
-	def hook(self):
-		log.debug("Hook thread start")
-		keyhook = keyboard_hook.KeyboardHook()
-		keyhook.register_callback(self.hook_callback)
-		msg = ctypes.wintypes.MSG()
-		while ctypes.windll.user32.GetMessageW(ctypes.byref(msg), None, 0, 0):
-			pass
-		log.debug("Hook thread end")
-		keyhook.free()
-
-	def hook_callback(self, **kwargs):
-		if not self.sendingKeys:
-			return False
-		keyCode = (kwargs['vk_code'], kwargs['extended'])
-		gesture = KeyboardInputGesture(self.keyModifiers, keyCode[0], kwargs['scan_code'], keyCode[1])
-		if not kwargs['pressed'] and keyCode in self.hostPendingModifiers:
-			self.hostPendingModifiers.discard(keyCode)
-			return False
-		gesture = KeyboardInputGesture(self.keyModifiers, keyCode[0], kwargs['scan_code'], keyCode[1])
-		if gesture.isModifier:
-			if kwargs['pressed']:
-				self.keyModifiers.add(keyCode)
-			else:
-				self.keyModifiers.discard(keyCode)
-		elif kwargs['pressed']:
-			script = gesture.script
-			if script in self.localScripts:
-				wx.CallAfter(script, gesture)
-				return True
-		self.masterTransport.send(RemoteMessageType.key, **kwargs)
-		return True #Don't pass it on
-
-	@script(
-		# Translators: Documentation string for the script that toggles the control between guest and host machine.
-		description=_("Toggles the control between guest and host machine"),
-		gesture="kb:f11",
-		)
-	def script_sendKeys(self, gesture):
-		if not self.masterTransport:
-			gesture.send()
-			return
-		self.sendingKeys = not self.sendingKeys
-		self.setReceivingBraille(self.sendingKeys)
-		if self.sendingKeys:
-			self.hostPendingModifiers = gesture.modifiers
-			# Translators: Presented when sending keyboard keys from the controlling computer to the controlled computer.
-			ui.message(_("Controlling remote machine."))
-		else:
-			self.releaseKeys()
-			# Translators: Presented when keyboard control is back to the controlling computer.
-			ui.message(_("Controlling local machine."))
-
-	def releaseKeys(self):
-		# release all pressed keys in the guest.
-		for k in self.keyModifiers:
-			self.masterTransport.send(RemoteMessageType.key, vk_code=k[0], extended=k[1], pressed=False)
-		self.keyModifiers = set()
-
-	def setReceivingBraille(self, state):
-		if state and self.masterSession.patchCallbacksAdded and braille.handler.enabled:
-			self.masterSession.patcher.registerBrailleInput()
-			self.localMachine.receivingBraille=True
-		elif not state:
-			self.masterSession.patcher.unregisterBrailleInput()
-			self.localMachine.receivingBraille=False
-
-	@alwaysCallAfter
-	def verifyAndConnect(self, conInfo: ConnectionInfo):
-		if self.isConnected() or self.connecting:
-			gui.messageBox(_("NVDA Remote is already connected. Disconnect before opening a new connection."), _("NVDA Remote Already Connected"), wx.OK|wx.ICON_WARNING)
-			return
-		self.connecting = True
-		serverAddr = conInfo.getAddress()
-		key = conInfo.key
-		if conInfo.mode == ConnectionMode.MASTER:
-			question = _("Do you wish to control the machine on server {server} with key {key}?").format(server=serverAddr, key=key)
-		elif conInfo.mode == ConnectionMode.SLAVE:
-			question = _("Do you wish to allow this machine to be controlled on server {server} with key {key}?").format(server=serverAddr, key=key)
-		if gui.messageBox(question, _("NVDA Remote Connection Request"), wx.YES|wx.NO|wx.NO_DEFAULT|wx.ICON_WARNING) != wx.YES:
-			self.connecting = False
-			return
-		self.connect(conInfo)
-		self.connecting = False
-
-	def isConnected(self):
-		connector = self.slaveTransport or self.masterTransport
-		if connector is not None:
-			return connector.connected
-		return False
+    @script(
+        # Translators: Documentation string for the script that toggles the control between guest and host machine.
+        description=_("Toggles the control between guest and host machine"),
+        gesture="kb:f11",
+    )
+    def script_sendKeys(self, gesture):
+        self.client.toggleRemoteKeyControl(gesture)

--- a/addon/globalPlugins/remoteClient/__init__.py
+++ b/addon/globalPlugins/remoteClient/__init__.py
@@ -10,66 +10,66 @@ from scriptHandler import script
 from .client import RemoteClient
 
 try:
-    addonHandler.initTranslation()
+	addonHandler.initTranslation()
 except addonHandler.AddonError:
-    log.warning(
-        "Unable to initialise translations. This may be because the addon is running from NVDA scratchpad."
-    )
+	log.warning(
+		"Unable to initialise translations. This may be because the addon is running from NVDA scratchpad."
+	)
 
 
 logging.getLogger("keyboard_hook").addHandler(logging.StreamHandler(sys.stdout))
 
 class GlobalPlugin(_GlobalPlugin):
-    scriptCategory: str = _("NVDA Remote")
-    client: RemoteClient
+	scriptCategory: str = _("NVDA Remote")
+	client: RemoteClient
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.client = RemoteClient()
-        self.client.registerLocalScript(self.script_sendKeys)
+	def __init__(self, *args, **kwargs):
+		super().__init__(*args, **kwargs)
+		self.client = RemoteClient()
+		self.client.registerLocalScript(self.script_sendKeys)
 
-    def terminate(self):
-        self.client.terminate()
+	def terminate(self):
+		self.client.terminate()
 
-    @script(
-        description=_("""Mute or unmute the speech coming from the remote computer""")
-    )
-    def script_toggle_remote_mute(self, gesture):
-        self.client.toggleMute()
+	@script(
+		description=_("""Mute or unmute the speech coming from the remote computer""")
+	)
+	def script_toggle_remote_mute(self, gesture):
+		self.client.toggleMute()
 
-    @script(
-        gesture="kb:control+shift+NVDA+c",
-        description=_("Sends the contents of the clipboard to the remote machine"),
-    )
-    def script_push_clipboard(self, gesture):
-        self.client.pushClipboard()
+	@script(
+		gesture="kb:control+shift+NVDA+c",
+		description=_("Sends the contents of the clipboard to the remote machine"),
+	)
+	def script_push_clipboard(self, gesture):
+		self.client.pushClipboard()
 
-    @script(description=_("""Copies a link to the remote session to the clipboard"""))
-    def script_copy_link(self, gesture):
-        self.client.copyLink()
-        ui.message(_("Copied link"))
+	@script(description=_("""Copies a link to the remote session to the clipboard"""))
+	def script_copy_link(self, gesture):
+		self.client.copyLink()
+		ui.message(_("Copied link"))
 
-    @script(
-        gesture="kb:alt+NVDA+pageDown", description=_("""Disconnect a remote session""")
-    )
-    def script_disconnect(self, gesture):
-        if not self.client.isConnected:
-            ui.message(_("Not connected."))
-            return
-        self.client.disconnect()
+	@script(
+		gesture="kb:alt+NVDA+pageDown", description=_("""Disconnect a remote session""")
+	)
+	def script_disconnect(self, gesture):
+		if not self.client.isConnected:
+			ui.message(_("Not connected."))
+			return
+		self.client.disconnect()
 
-    @script(
-        gesture="kb:alt+NVDA+pageUp", description=_("""Connect to a remote computer""")
-    )
-    def script_connect(self, gesture):
-        if self.client.isConnected() or self.client.connecting:
-            return
-        self.client.doConnect()
+	@script(
+		gesture="kb:alt+NVDA+pageUp", description=_("""Connect to a remote computer""")
+	)
+	def script_connect(self, gesture):
+		if self.client.isConnected() or self.client.connecting:
+			return
+		self.client.doConnect()
 
-    @script(
-        # Translators: Documentation string for the script that toggles the control between guest and host machine.
-        description=_("Toggles the control between guest and host machine"),
-        gesture="kb:f11",
-    )
-    def script_sendKeys(self, gesture):
-        self.client.toggleRemoteKeyControl(gesture)
+	@script(
+		# Translators: Documentation string for the script that toggles the control between guest and host machine.
+		description=_("Toggles the control between guest and host machine"),
+		gesture="kb:f11",
+	)
+	def script_sendKeys(self, gesture):
+		self.client.toggleRemoteKeyControl(gesture)

--- a/addon/globalPlugins/remoteClient/bridge.py
+++ b/addon/globalPlugins/remoteClient/bridge.py
@@ -1,5 +1,4 @@
-from typing import Any, Set, Dict
-from enum import Enum
+from typing import Dict, Set
 from .protocol import RemoteMessageType
 from .transport import Transport
 

--- a/addon/globalPlugins/remoteClient/client.py
+++ b/addon/globalPlugins/remoteClient/client.py
@@ -67,8 +67,7 @@ class RemoteClient:
 	sendingKeys: bool
 
 
-	def __init__(self, *args, **kwargs):
-		super().__init__(*args, **kwargs)
+	def __init__(self, ):
 		self.keyModifiers = set()
 		self.hostPendingModifiers = set()
 		self.localScripts = {self.toggleRemoteKeyControl}

--- a/addon/globalPlugins/remoteClient/client.py
+++ b/addon/globalPlugins/remoteClient/client.py
@@ -93,7 +93,7 @@ class RemoteClient:
 		if isRunningOnSecureDesktop():
 			connection = self.sdHandler.initializeSecureDesktop()
 			if connection:
-				self.connectAsSlave(connection.address, connection.channel, insecure=True)
+				self.connectAsSlave(connection)
 				self.slaveSession.transport.connectedEvent.wait(self.sdHandler.SD_CONNECT_BLOCK_TIMEOUT)
 		core.postNvdaStartup.register(self.performAutoconnect)
 

--- a/addon/globalPlugins/remoteClient/client.py
+++ b/addon/globalPlugins/remoteClient/client.py
@@ -18,7 +18,6 @@ import speech
 import ui
 import wx
 from config import isInstalledCopy
-from globalPluginHandler import GlobalPlugin as _GlobalPlugin
 from keyboardHandler import KeyboardInputGesture
 from logHandler import log
 from utils.security import isRunningOnSecureDesktop
@@ -70,7 +69,7 @@ class RemoteClient:
 	def __init__(self, ):
 		self.keyModifiers = set()
 		self.hostPendingModifiers = set()
-		self.localScripts = {self.toggleRemoteKeyControl}
+		self.localScripts = set()
 		self.localMachine = local_machine.LocalMachine()
 		self.slaveSession = None
 		self.masterSession = None
@@ -340,7 +339,7 @@ class RemoteClient:
 		self.masterTransport.send(RemoteMessageType.key, **kwargs)
 		return True #Don't pass it on
 
-	def toggleRemoteKeyControl(self, gesture):
+	def toggleRemoteKeyControl(self, gesture: KeyboardInputGesture):
 		if not self.masterTransport:
 			gesture.send()
 			return
@@ -392,3 +391,9 @@ class RemoteClient:
 		if connector is not None:
 			return connector.connected
 		return False
+
+	def registerLocalScript(self, script):
+		self.localScripts.add(script)
+
+	def unregisterLocalScript(self, script):
+		self.localScripts.discard(script)

--- a/addon/globalPlugins/remoteClient/client.py
+++ b/addon/globalPlugins/remoteClient/client.py
@@ -290,7 +290,8 @@ class RemoteClient:
 	@alwaysCallAfter
 	def onSlaveCertificateFailed(self):
 		if self.handleCertificateFailure(self.slaveTransport):
-			self.connectAsSlave(self.lastFailAddress, self.lastFailKey, True)
+			connectionInfo = ConnectionInfo(mode=ConnectionMode.SLAVE, hostname=self.lastFailAddress[0], port=self.lastFailAddress[1], key=self.lastFailKey, insecure=True)
+			self.connectAsSlave(connectionInfo=connectionInfo)
 
 	@alwaysCallAfter
 	def onConnectedAsSlave(self):

--- a/addon/globalPlugins/remoteClient/client.py
+++ b/addon/globalPlugins/remoteClient/client.py
@@ -1,0 +1,395 @@
+import ctypes
+import ctypes.wintypes
+import logging
+import os
+import sys
+import threading
+from typing import Callable, Optional, Set, Tuple
+
+import addonHandler
+import api
+import braille
+import configobj
+import core
+import globalVars
+import gui
+import queueHandler
+import speech
+import ui
+import wx
+from config import isInstalledCopy
+from globalPluginHandler import GlobalPlugin as _GlobalPlugin
+from keyboardHandler import KeyboardInputGesture
+from logHandler import log
+from utils.security import isRunningOnSecureDesktop
+
+from . import configuration, cues, local_machine, serializer, url_handler
+from .alwaysCallAfter import alwaysCallAfter
+from .connection_info import ConnectionInfo, ConnectionMode
+from .menu import RemoteMenu
+from .protocol import RemoteMessageType
+from .secureDesktop import SecureDesktopHandler
+from .session import MasterSession, SlaveSession
+from .settings_panel import RemoteSettingsPanel
+from .transport import RelayTransport
+
+try:
+	addonHandler.initTranslation()
+except addonHandler.AddonError:
+	log.warning(
+		"Unable to initialise translations. This may be because the addon is running from NVDA scratchpad."
+	)
+from winUser import WM_QUIT  # provided by NVDA
+
+from . import dialogs, keyboard_hook, server
+from .socket_utils import addressToHostPort, hostPortToAddress
+
+logging.getLogger("keyboard_hook").addHandler(logging.StreamHandler(sys.stdout))
+
+# Type aliases
+KeyModifier = Tuple[int, bool]  # (vk_code, extended)
+Address = Tuple[str, int]  # (hostname, port) 
+
+
+
+class RemoteClient:
+	localScripts: Set[Callable]
+	localMachine: local_machine.LocalMachine
+	masterSession: Optional[MasterSession] 
+	slaveSession: Optional[SlaveSession]
+	keyModifiers: Set[KeyModifier]
+	hostPendingModifiers: Set[KeyModifier]
+	connecting: bool
+	masterTransport: Optional[RelayTransport]
+	slaveTransport: Optional[RelayTransport]
+	localControlServer: Optional[server.LocalRelayServer]
+	hookThread: Optional[threading.Thread]
+	sendingKeys: bool
+
+
+	def __init__(self, *args, **kwargs):
+		super().__init__(*args, **kwargs)
+		self.keyModifiers = set()
+		self.hostPendingModifiers = set()
+		self.localScripts = {self.toggleRemoteKeyControl}
+		self.localMachine = local_machine.LocalMachine()
+		self.slaveSession = None
+		self.masterSession = None
+		self.menu: RemoteMenu = RemoteMenu(self)
+		self.connecting = False
+		self.URLHandlerWindow = url_handler.URLHandlerWindow(callback=self.verifyAndConnect)
+		url_handler.register_url_handler()
+		self.masterTransport = None
+		self.slaveTransport = None
+		self.localControlServer = None
+		self.hookThread = None
+		self.sendingKeys = False
+		try:
+			configuration.get_config()
+		except configobj.ParseError:
+			os.remove(os.path.abspath(os.path.join(globalVars.appArgs.configPath, configuration.CONFIG_FILE_NAME)))
+			queueHandler.queueFunction(queueHandler.eventQueue, wx.CallAfter, wx.MessageBox, _("Your NVDA Remote configuration was corrupted and has been reset."), _("NVDA Remote Configuration Error"), wx.OK|wx.ICON_EXCLAMATION)
+		if not globalVars.appArgs.secure:
+			gui.settingsDialogs.NVDASettingsDialog.categoryClasses.append(RemoteSettingsPanel)
+		self.sdHandler = SecureDesktopHandler()
+		if isRunningOnSecureDesktop():
+			connection = self.sdHandler.initializeSecureDesktop()
+			if connection:
+				self.connectAsSlave(connection.address, connection.channel, insecure=True)
+				self.slaveSession.transport.connectedEvent.wait(self.sdHandler.SD_CONNECT_BLOCK_TIMEOUT)
+		core.postNvdaStartup.register(self.performAutoconnect)
+
+	def performAutoconnect(self):
+		controlServerConfig = configuration.get_config()['controlserver']
+		if not controlServerConfig['autoconnect'] or self.masterSession or self.slaveSession:
+			log.debug("Autoconnect disabled or already connected")
+			return
+		key  = controlServerConfig['key']
+		if controlServerConfig['self_hosted']:
+			port = controlServerConfig['port']
+			hostname = 'localhost'
+			self.startControlServer(port, key )
+		else:
+			address = addressToHostPort(controlServerConfig['host'])
+			hostname, port = address
+		mode = ConnectionMode.SLAVE if controlServerConfig['connection_type']==0 else ConnectionMode.MASTER
+		conInfo = ConnectionInfo(mode=mode, hostname=hostname, port=port, key=key)
+		self.connect(conInfo)
+
+	def terminate(self):
+		self.sdHandler.terminate()
+		self.disconnect()
+		self.localMachine.terminate()
+		self.localMachine = None
+		self.menu.terminate()
+		self.menu=None
+		if not isInstalledCopy():
+			url_handler.unregister_url_handler()
+		self.URLHandlerWindow.destroy()
+		self.URLHandlerWindow=None
+		if not globalVars.appArgs.secure:
+			gui.settingsDialogs.NVDASettingsDialog.categoryClasses.remove(RemoteSettingsPanel)
+
+
+	def toggleMute(self):
+		self.localMachine.isMuted = not self.localMachine.isMuted
+		self.menu.muteItem.Check(self.localMachine.isMuted)
+		# Translators: Report when using gestures to mute or unmute the speech coming from the remote computer.
+		status = _("Mute speech and sounds from the remote computer") if self.localMachine.isMuted else _("Unmute speech and sounds from the remote computer")
+		ui.message(status)
+
+	def pushClipboard(self):
+		connector = self.slaveTransport or self.masterTransport
+		if not getattr(connector,'connected',False):
+			ui.message(_("Not connected."))
+			return
+		try:
+			connector.send(RemoteMessageType.set_clipboard_text, text=api.getClipData())
+			cues.clipboard_pushed()
+			ui.message(_("Clipboard pushed"))
+		except TypeError:
+			log.exception("Unable to push clipboard")
+
+	def copyLink(self):
+		session = self.masterSession or self.slaveSession
+		url = session.getConnectionInfo().getURLToConnect()
+		api.copyToClip(str(url))
+
+	def sendSAS(self):
+		self.masterTransport.send(RemoteMessageType.send_SAS)
+
+	def connect(self, connectionInfo: ConnectionInfo, insecure=False):
+		if connectionInfo.mode == ConnectionMode.MASTER:
+			self.connectAsMaster((connectionInfo.hostname, connectionInfo.port), connectionInfo.key, insecure)
+		elif connectionInfo.mode == ConnectionMode.SLAVE:
+			self.connectAsSlave((connectionInfo.hostname, connectionInfo.port), connectionInfo.key, insecure)
+
+	def disconnect(self):
+		if self.masterTransport is None and self.slaveTransport is None:
+			return
+		if self.localControlServer is not None:
+			self.localControlServer.close()
+			self.localControlServer = None
+		if self.masterTransport is not None:
+			self.disconnectAsMaster()
+		if self.slaveTransport is not None:
+			self.disconnectAsSlave()
+		cues.disconnected()
+		self.menu.handleConnected(False)
+
+	def disconnectAsMaster(self):
+		self.masterTransport.close()
+		self.masterTransport = None
+		self.masterSession = None
+
+	def disconnectingAsMaster(self):
+		if self.menu:
+			self.menu.handleConnected(False)
+		if self.localMachine:
+			self.localMachine.isMuted = False
+		self.sendingKeys = False
+		if self.hookThread is not None:
+			ctypes.windll.user32.PostThreadMessageW(self.hookThread.ident, WM_QUIT, 0, 0)
+			self.hookThread.join()
+			self.hookThread = None
+		self.keyModifiers = set()
+
+	def disconnectAsSlave(self):
+		self.slaveTransport.close()
+		self.slaveTransport = None
+		self.slaveSession = None
+		self.sdHandler.slaveSession = None
+
+	@alwaysCallAfter
+	def onConnectAsMasterFailed(self):
+		if self.masterTransport.successfulConnects == 0:
+			self.disconnectAsMaster()
+			# Translators: Title of the connection error dialog.
+			gui.messageBox(parent=gui.mainFrame, caption=_("Error Connecting"),
+			# Translators: Message shown when cannot connect to the remote computer.
+			message=_("Unable to connect to the remote computer"), style=wx.OK | wx.ICON_WARNING)
+
+	def doConnect(self, evt=None):
+		if evt is not None:
+			evt.Skip()
+		previousConnections = configuration.get_config()['connections']['last_connected']
+		hostnames = list(reversed(previousConnections))
+		# Translators: Title of the connect dialog.
+		dlg = dialogs.DirectConnectDialog(parent=gui.mainFrame, id=wx.ID_ANY, title=_("Connect"), hostnames=hostnames)
+		
+		def handleDialogCompletion(dlgResult):
+			if dlgResult != wx.ID_OK:
+				return
+			connectionInfo = dlg.getConnectionInfo()
+			if dlg.client_or_server.GetSelection() == 1:  # server
+				self.startControlServer(connectionInfo.port, connectionInfo.key)
+			self.connect(connectionInfo=connectionInfo, insecure=dlg.client_or_server.GetSelection() == 1)
+		gui.runScriptModalDialog(dlg, callback=handleDialogCompletion)
+
+	def onConnectedAsMaster(self):
+		configuration.write_connection_to_config(self.masterTransport.address)
+		self.menu.handleConnected(True)
+		# We might have already created a hook thread before if we're restoring an
+		# interrupted connection. We must not create another.
+		if not self.hookThread:
+			self.hookThread = threading.Thread(target=self.hook)
+			self.hookThread.daemon = True
+			self.hookThread.start()
+		# Translators: Presented when connected to the remote computer.
+		ui.message(_("Connected!"))
+		cues.connected()
+
+	def onDisconnectedAsMaster(self):
+		# Translators: Presented when connection to a remote computer was interupted.
+		ui.message(_("Connection interrupted"))
+
+	def connectAsMaster(self, address, key, insecure=False):
+		transport = RelayTransport(address=address, serializer=serializer.JSONSerializer(), channel=key, connectionType='master', insecure=insecure)
+		self.masterSession = MasterSession(transport=transport, localMachine=self.localMachine)
+		transport.transportCertificateAuthenticationFailed.register(self.onMasterCertificateFailed)
+		transport.transportConnected.register(self.onConnectedAsMaster)
+		transport.transportConnectionFailed.register(self.onConnectAsMasterFailed)
+		transport.transportClosing.register(self.disconnectingAsMaster)
+		transport.transportDisconnected.register(self.onDisconnectedAsMaster)
+		transport.reconnectorThread.start()
+		self.masterTransport = transport
+
+	def connectAsSlave(self, address, key, insecure=False):
+		transport = RelayTransport(serializer=serializer.JSONSerializer(), address=address, channel=key, connectionType='slave', insecure=insecure)
+		self.slaveSession = SlaveSession(transport=transport, localMachine=self.localMachine)
+		self.sdHandler.slaveSession = self.slaveSession
+		self.slaveTransport = transport
+		transport.transportCertificateAuthenticationFailed.register(self.onSlaveCertificateFailed)
+		transport.transportConnected.register(self.onConnectedAsSlave)
+		transport.reconnectorThread.start()
+		self.menu.disconnectItem.Enable(True)
+		self.menu.connectItem.Enable(False)
+
+	def handleCertificateFailure(self, transport: RelayTransport):
+		self.lastFailAddress = transport.address
+		self.lastFailKey = transport.channel
+		self.disconnect()
+		try:
+			certHash = transport.lastFailFingerprint
+
+			wnd = dialogs.CertificateUnauthorizedDialog(None, fingerprint=certHash)
+			a = wnd.ShowModal()
+			if a == wx.ID_YES:
+				config = configuration.get_config()
+				config['trusted_certs'][hostPortToAddress(self.lastFailAddress)]=certHash
+				config.write()
+			if a == wx.ID_YES or a == wx.ID_NO: return True
+		except Exception as ex:
+			log.error(ex)
+		return False
+
+	@alwaysCallAfter
+	def onMasterCertificateFailed(self):
+		if self.handleCertificateFailure(self.masterTransport):
+			self.connectAsMaster(self.lastFailAddress, self.lastFailKey, True)
+
+	@alwaysCallAfter
+	def onSlaveCertificateFailed(self):
+		if self.handleCertificateFailure(self.slaveTransport):
+			self.connectAsSlave(self.lastFailAddress, self.lastFailKey, True)
+
+	@alwaysCallAfter
+	def onConnectedAsSlave(self):
+		log.info("Control connector connected")
+		cues.control_server_connected()
+		# Translators: Presented in direct (client to server) remote connection when the controlled computer is ready.
+		speech.speakMessage(_("Connected to control server"))
+		self.menu.pushClipboardItem.Enable(True)
+		self.menu.copyLinkItem.Enable(True)
+		configuration.write_connection_to_config(self.slaveTransport.address)
+
+	def startControlServer(self, serverPort, channel):
+		self.localControlServer = server.LocalRelayServer(serverPort, channel)
+		serverThread = threading.Thread(target=self.localControlServer.run)
+		serverThread.daemon = True
+		serverThread.start()
+
+	def hook(self):
+		log.debug("Hook thread start")
+		keyhook = keyboard_hook.KeyboardHook()
+		keyhook.register_callback(self.hook_callback)
+		msg = ctypes.wintypes.MSG()
+		while ctypes.windll.user32.GetMessageW(ctypes.byref(msg), None, 0, 0):
+			pass
+		log.debug("Hook thread end")
+		keyhook.free()
+
+	def hook_callback(self, **kwargs):
+		if not self.sendingKeys:
+			return False
+		keyCode = (kwargs['vk_code'], kwargs['extended'])
+		gesture = KeyboardInputGesture(self.keyModifiers, keyCode[0], kwargs['scan_code'], keyCode[1])
+		if not kwargs['pressed'] and keyCode in self.hostPendingModifiers:
+			self.hostPendingModifiers.discard(keyCode)
+			return False
+		gesture = KeyboardInputGesture(self.keyModifiers, keyCode[0], kwargs['scan_code'], keyCode[1])
+		if gesture.isModifier:
+			if kwargs['pressed']:
+				self.keyModifiers.add(keyCode)
+			else:
+				self.keyModifiers.discard(keyCode)
+		elif kwargs['pressed']:
+			script = gesture.script
+			if script in self.localScripts:
+				wx.CallAfter(script, gesture)
+				return True
+		self.masterTransport.send(RemoteMessageType.key, **kwargs)
+		return True #Don't pass it on
+
+	def toggleRemoteKeyControl(self, gesture):
+		if not self.masterTransport:
+			gesture.send()
+			return
+		self.sendingKeys = not self.sendingKeys
+		self.setReceivingBraille(self.sendingKeys)
+		if self.sendingKeys:
+			self.hostPendingModifiers = gesture.modifiers
+			# Translators: Presented when sending keyboard keys from the controlling computer to the controlled computer.
+			ui.message(_("Controlling remote machine."))
+		else:
+			self.releaseKeys()
+			# Translators: Presented when keyboard control is back to the controlling computer.
+			ui.message(_("Controlling local machine."))
+
+	def releaseKeys(self):
+		# release all pressed keys in the guest.
+		for k in self.keyModifiers:
+			self.masterTransport.send(RemoteMessageType.key, vk_code=k[0], extended=k[1], pressed=False)
+		self.keyModifiers = set()
+
+	def setReceivingBraille(self, state):
+		if state and self.masterSession.patchCallbacksAdded and braille.handler.enabled:
+			self.masterSession.patcher.registerBrailleInput()
+			self.localMachine.receivingBraille=True
+		elif not state:
+			self.masterSession.patcher.unregisterBrailleInput()
+			self.localMachine.receivingBraille=False
+
+	@alwaysCallAfter
+	def verifyAndConnect(self, conInfo: ConnectionInfo):
+		if self.isConnected() or self.connecting:
+			gui.messageBox(_("NVDA Remote is already connected. Disconnect before opening a new connection."), _("NVDA Remote Already Connected"), wx.OK|wx.ICON_WARNING)
+			return
+		self.connecting = True
+		serverAddr = conInfo.getAddress()
+		key = conInfo.key
+		if conInfo.mode == ConnectionMode.MASTER:
+			question = _("Do you wish to control the machine on server {server} with key {key}?").format(server=serverAddr, key=key)
+		elif conInfo.mode == ConnectionMode.SLAVE:
+			question = _("Do you wish to allow this machine to be controlled on server {server} with key {key}?").format(server=serverAddr, key=key)
+		if gui.messageBox(question, _("NVDA Remote Connection Request"), wx.YES|wx.NO|wx.NO_DEFAULT|wx.ICON_WARNING) != wx.YES:
+			self.connecting = False
+			return
+		self.connect(conInfo)
+		self.connecting = False
+
+	def isConnected(self):
+		connector = self.slaveTransport or self.masterTransport
+		if connector is not None:
+			return connector.connected
+		return False

--- a/addon/globalPlugins/remoteClient/configuration.py
+++ b/addon/globalPlugins/remoteClient/configuration.py
@@ -6,6 +6,7 @@ import globalVars
 from configobj import validate
 
 from . import socket_utils
+from .connection_info import ConnectionInfo
 
 CONFIG_FILE_NAME = 'remote.ini'
 
@@ -39,12 +40,16 @@ def get_config():
 		_config.validate(val, copy=True)
 	return _config
 
-def write_connection_to_config(address):
-	"""Writes an address to the last connected section of the config.
-	If the address is already in the config, move it to the end."""
+def write_connection_to_config(connection_info: ConnectionInfo):
+	"""Writes a connection to the last connected section of the config.
+	If the connection is already in the config, move it to the end.
+	
+	Args:
+		connection_info: The ConnectionInfo object containing connection details
+	"""
 	conf = get_config()
 	last_cons = conf['connections']['last_connected']
-	address = socket_utils.hostPortToAddress(address)
+	address = connection_info.getAddress()
 	if address in last_cons:
 		conf['connections']['last_connected'].remove(address)
 	conf['connections']['last_connected'].append(address)

--- a/addon/globalPlugins/remoteClient/configuration.py
+++ b/addon/globalPlugins/remoteClient/configuration.py
@@ -5,7 +5,6 @@ import configobj
 import globalVars
 from configobj import validate
 
-from . import socket_utils
 from .connection_info import ConnectionInfo
 
 CONFIG_FILE_NAME = 'remote.ini'

--- a/addon/globalPlugins/remoteClient/local_machine.py
+++ b/addon/globalPlugins/remoteClient/local_machine.py
@@ -16,9 +16,9 @@ from speech.types import SpeechSequence
 from . import cues, input
 
 try:
-    from systemUtils import hasUiAccess
+	from systemUtils import hasUiAccess
 except ModuleNotFoundError:
-    from config import hasUiAccess
+	from config import hasUiAccess
 
 
 import ui

--- a/addon/globalPlugins/remoteClient/menu.py
+++ b/addon/globalPlugins/remoteClient/menu.py
@@ -1,136 +1,141 @@
 import wx
 
+from .connection_info import ConnectionMode
 import gui
 
 
 class RemoteMenu(wx.Menu):
-    """Menu for the NVDA Remote addon that appears in the NVDA Tools menu"""
+	"""Menu for the NVDA Remote addon that appears in the NVDA Tools menu"""
 
-    connectItem: wx.MenuItem
-    disconnectItem: wx.MenuItem
-    muteItem: wx.MenuItem
-    pushClipboardItem: wx.MenuItem
-    copyLinkItem: wx.MenuItem
-    sendCtrlAltDelItem: wx.MenuItem
-    remoteItem: wx.MenuItem
+	connectItem: wx.MenuItem
+	disconnectItem: wx.MenuItem
+	muteItem: wx.MenuItem
+	pushClipboardItem: wx.MenuItem
+	copyLinkItem: wx.MenuItem
+	sendCtrlAltDelItem: wx.MenuItem
+	remoteItem: wx.MenuItem
 
-    def __init__(self, client) -> None:
-        super().__init__()
-        self.client = client
-        toolsMenu = gui.mainFrame.sysTrayIcon.toolsMenu
-        # Translators: Item in NVDA Remote submenu to connect to a remote computer.
-        self.connectItem: wx.MenuItem = self.Append(
-            wx.ID_ANY,
-            _("Connect..."),
-            _("Remotely connect to another computer running NVDA Remote Access"),
-        )
-        gui.mainFrame.sysTrayIcon.Bind(
-            wx.EVT_MENU, self.client.doConnect, self.connectItem
-        )
-        # Translators: Item in NVDA Remote submenu to disconnect from a remote computer.
-        self.disconnectItem: wx.MenuItem = self.Append(
-            wx.ID_ANY,
-            _("Disconnect"),
-            _("Disconnect from another computer running NVDA Remote Access"),
-        )
-        self.disconnectItem.Enable(False)
-        gui.mainFrame.sysTrayIcon.Bind(
-            wx.EVT_MENU, self.onDisconnectItem, self.disconnectItem
-        )
-        # Translators: Menu item in NvDA Remote submenu to mute speech and sounds from the remote computer.
-        self.muteItem: wx.MenuItem = self.Append(
-            wx.ID_ANY,
-            _("Mute remote"),
-            _("Mute speech and sounds from the remote computer"),
-            kind=wx.ITEM_CHECK,
-        )
-        self.muteItem.Enable(False)
-        gui.mainFrame.sysTrayIcon.Bind(wx.EVT_MENU, self.onMuteItem, self.muteItem)
-        # Translators: Menu item in NVDA Remote submenu to push clipboard content to the remote computer.
-        self.pushClipboardItem: wx.MenuItem = self.Append(
-            wx.ID_ANY,
-            _("&Push clipboard"),
-            _("Push the clipboard to the other machine"),
-        )
-        self.pushClipboardItem.Enable(False)
-        gui.mainFrame.sysTrayIcon.Bind(
-            wx.EVT_MENU, self.onPushClipboardItem, self.pushClipboardItem
-        )
-        # Translators: Menu item in NVDA Remote submenu to copy a link to the current session.
-        self.copyLinkItem: wx.MenuItem = self.Append(
-            wx.ID_ANY, _("Copy &link"), _("Copy a link to the remote session")
-        )
-        self.copyLinkItem.Enable(False)
-        gui.mainFrame.sysTrayIcon.Bind(
-            wx.EVT_MENU, self.onCopyLinkItem, self.copyLinkItem
-        )
-        # Translators: Menu item in NVDA Remote submenu to send Control+Alt+Delete to the remote computer.
-        self.sendCtrlAltDelItem: wx.MenuItem = self.Append(
-            wx.ID_ANY, _("Send Ctrl+Alt+Del"), _("Send Ctrl+Alt+Del")
-        )
-        gui.mainFrame.sysTrayIcon.Bind(
-            wx.EVT_MENU, self.onSendCtrlAltDel, self.sendCtrlAltDelItem
-        )
-        self.sendCtrlAltDelItem.Enable(False)
-        # Translators: Label of menu in NVDA tools menu.
-        self.remoteItem = toolsMenu.AppendSubMenu(
-            self, _("R&emote"), _("NVDA Remote Access")
-        )
+	def __init__(self, client) -> None:
+		super().__init__()
+		self.client = client
+		toolsMenu = gui.mainFrame.sysTrayIcon.toolsMenu
+		# Translators: Item in NVDA Remote submenu to connect to a remote computer.
+		self.connectItem: wx.MenuItem = self.Append(
+			wx.ID_ANY,
+			_("Connect..."),
+			_("Remotely connect to another computer running NVDA Remote Access"),
+		)
+		gui.mainFrame.sysTrayIcon.Bind(
+			wx.EVT_MENU, self.client.doConnect, self.connectItem
+		)
+		# Translators: Item in NVDA Remote submenu to disconnect from a remote computer.
+		self.disconnectItem: wx.MenuItem = self.Append(
+			wx.ID_ANY,
+			_("Disconnect"),
+			_("Disconnect from another computer running NVDA Remote Access"),
+		)
+		self.disconnectItem.Enable(False)
+		gui.mainFrame.sysTrayIcon.Bind(
+			wx.EVT_MENU, self.onDisconnectItem, self.disconnectItem
+		)
+		# Translators: Menu item in NvDA Remote submenu to mute speech and sounds from the remote computer.
+		self.muteItem: wx.MenuItem = self.Append(
+			wx.ID_ANY,
+			_("Mute remote"),
+			_("Mute speech and sounds from the remote computer"),
+			kind=wx.ITEM_CHECK,
+		)
+		self.muteItem.Enable(False)
+		gui.mainFrame.sysTrayIcon.Bind(wx.EVT_MENU, self.onMuteItem, self.muteItem)
+		# Translators: Menu item in NVDA Remote submenu to push clipboard content to the remote computer.
+		self.pushClipboardItem: wx.MenuItem = self.Append(
+			wx.ID_ANY,
+			_("&Push clipboard"),
+			_("Push the clipboard to the other machine"),
+		)
+		self.pushClipboardItem.Enable(False)
+		gui.mainFrame.sysTrayIcon.Bind(
+			wx.EVT_MENU, self.onPushClipboardItem, self.pushClipboardItem
+		)
+		# Translators: Menu item in NVDA Remote submenu to copy a link to the current session.
+		self.copyLinkItem: wx.MenuItem = self.Append(
+			wx.ID_ANY, _("Copy &link"), _("Copy a link to the remote session")
+		)
+		self.copyLinkItem.Enable(False)
+		gui.mainFrame.sysTrayIcon.Bind(
+			wx.EVT_MENU, self.onCopyLinkItem, self.copyLinkItem
+		)
+		# Translators: Menu item in NVDA Remote submenu to send Control+Alt+Delete to the remote computer.
+		self.sendCtrlAltDelItem: wx.MenuItem = self.Append(
+			wx.ID_ANY, _("Send Ctrl+Alt+Del"), _("Send Ctrl+Alt+Del")
+		)
+		gui.mainFrame.sysTrayIcon.Bind(
+			wx.EVT_MENU, self.onSendCtrlAltDel, self.sendCtrlAltDelItem
+		)
+		self.sendCtrlAltDelItem.Enable(False)
+		# Translators: Label of menu in NVDA tools menu.
+		self.remoteItem = toolsMenu.AppendSubMenu(
+			self, _("R&emote"), _("NVDA Remote Access")
+		)
 
-    def terminate(self) -> None:
-        self.Remove(self.connectItem.Id)
-        self.connectItem.Destroy()
-        self.connectItem = None
-        self.Remove(self.disconnectItem.Id)
-        self.disconnectItem.Destroy()
-        self.disconnectItem = None
-        self.Remove(self.muteItem.Id)
-        self.muteItem.Destroy()
-        self.muteItem = None
-        self.Remove(self.pushClipboardItem.Id)
-        self.pushClipboardItem.Destroy()
-        self.pushClipboardItem = None
-        self.Remove(self.copyLinkItem.Id)
-        self.copyLinkItem.Destroy()
-        self.copyLinkItem = None
-        self.Remove(self.sendCtrlAltDelItem.Id)
-        self.sendCtrlAltDelItem.Destroy()
-        self.sendCtrlAltDelItem = None
-        tools_menu = gui.mainFrame.sysTrayIcon.toolsMenu
-        tools_menu.Remove(self.remoteItem.Id)
-        self.remoteItem.Destroy()
-        self.remoteItem = None
-        try:
-            self.Destroy()
-        except (RuntimeError, AttributeError):
-            pass
+	def terminate(self) -> None:
+		self.Remove(self.connectItem.Id)
+		self.connectItem.Destroy()
+		self.connectItem = None
+		self.Remove(self.disconnectItem.Id)
+		self.disconnectItem.Destroy()
+		self.disconnectItem = None
+		self.Remove(self.muteItem.Id)
+		self.muteItem.Destroy()
+		self.muteItem = None
+		self.Remove(self.pushClipboardItem.Id)
+		self.pushClipboardItem.Destroy()
+		self.pushClipboardItem = None
+		self.Remove(self.copyLinkItem.Id)
+		self.copyLinkItem.Destroy()
+		self.copyLinkItem = None
+		self.Remove(self.sendCtrlAltDelItem.Id)
+		self.sendCtrlAltDelItem.Destroy()
+		self.sendCtrlAltDelItem = None
+		tools_menu = gui.mainFrame.sysTrayIcon.toolsMenu
+		tools_menu.Remove(self.remoteItem.Id)
+		self.remoteItem.Destroy()
+		self.remoteItem = None
+		try:
+			self.Destroy()
+		except (RuntimeError, AttributeError):
+			pass
 
-    def onDisconnectItem(self, evt: wx.CommandEvent) -> None:
-        evt.Skip()
-        self.client.disconnect()
+	def onDisconnectItem(self, evt: wx.CommandEvent) -> None:
+		evt.Skip()
+		self.client.disconnect()
 
-    def onMuteItem(self, evt: wx.CommandEvent) -> None:
-        evt.Skip()
-        self.client.toggleMute()
+	def onMuteItem(self, evt: wx.CommandEvent) -> None:
+		evt.Skip()
+		self.client.toggleMute()
 
-    def onPushClipboardItem(self, evt: wx.CommandEvent) -> None:
-        evt.Skip()
-        self.client.pushClipboard()
+	def onPushClipboardItem(self, evt: wx.CommandEvent) -> None:
+		evt.Skip()
+		self.client.pushClipboard()
 
-    def onCopyLinkItem(self, evt: wx.CommandEvent) -> None:
-        evt.Skip()
-        self.client.copyLink()
+	def onCopyLinkItem(self, evt: wx.CommandEvent) -> None:
+		evt.Skip()
+		self.client.copyLink()
 
-    def onSendCtrlAltDel(self, evt: wx.CommandEvent) -> None:
-        evt.Skip()
-        self.client.sendSAS()
+	def onSendCtrlAltDel(self, evt: wx.CommandEvent) -> None:
+		evt.Skip()
+		self.client.sendSAS()
 
-    def handleConnected(self, connected: bool) -> None:
-        self.connectItem.Enable(not connected)
-        self.disconnectItem.Enable(connected)
-        self.muteItem.Enable(connected)
-        if not connected:
-            self.muteItem.Check(False)
-        self.pushClipboardItem.Enable(connected)
-        self.copyLinkItem.Enable(connected)
-        self.sendCtrlAltDelItem.Enable(connected)
+	def handleConnected(self, mode: ConnectionMode, connected: bool) -> None:
+		self.connectItem.Enable(not connected)
+		self.disconnectItem.Enable(connected)
+		self.muteItem.Enable(connected)
+		if not connected:
+			self.muteItem.Check(False)
+		self.pushClipboardItem.Enable(connected)
+		self.copyLinkItem.Enable(connected)
+		self.sendCtrlAltDelItem.Enable(connected)
+
+	def handleConnecting(self, mode: ConnectionMode) -> None:
+		self.disconnectItem.Enable(True)
+		self.connectItem.Enable(False)

--- a/addon/globalPlugins/remoteClient/secureDesktop.py
+++ b/addon/globalPlugins/remoteClient/secureDesktop.py
@@ -172,7 +172,8 @@ class SecureDesktopHandler:
 				hostname='127.0.0.1',
 				mode=ConnectionMode.SLAVE,
 				key=channel,
-				port=port
+				port=port,
+				insecure=True
 			)
 			
 		except Exception:

--- a/addon/globalPlugins/remoteClient/secureDesktop.py
+++ b/addon/globalPlugins/remoteClient/secureDesktop.py
@@ -151,7 +151,7 @@ class SecureDesktopHandler:
 		except FileNotFoundError:
 			pass
 
-	def initializeSecureDesktop(self) -> Optional[SecureDesktopConnection]:
+	def initializeSecureDesktop(self) -> Optional[ConnectionInfo]:
 		"""
 		Initialize connection when starting in secure desktop.
 		

--- a/addon/globalPlugins/remoteClient/secureDesktop.py
+++ b/addon/globalPlugins/remoteClient/secureDesktop.py
@@ -3,11 +3,11 @@ import socket
 import ssl
 import threading
 import uuid
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional, Tuple
 
 import shlobj
+from .connection_info import ConnectionInfo, ConnectionMode
 from logHandler import log
 from winAPI.secureDesktop import post_secureDesktopStateChange
 
@@ -24,11 +24,6 @@ def getProgramDataTempPath() -> Path:
 		return Path(shlobj.SHGetKnownFolderPath(shlobj.FolderId.PROGRAM_DATA)) / 'temp'
 	return Path(shlobj.SHGetFolderPath(0, shlobj.CSIDL_COMMON_APPDATA)) / 'temp'
 
-@dataclass(frozen=True)
-class SecureDesktopConnection:
-	"""Connection details for secure desktop."""
-	address: Tuple[str, int]
-	channel: str
 
 class SecureDesktopHandler:
 	"""Handles secure desktop transitions and management of secure desktop connections."""
@@ -173,9 +168,11 @@ class SecureDesktopHandler:
 			testSocket.connect(('127.0.0.1', port))
 			testSocket.close()
 
-			return SecureDesktopConnection(
-				address=('127.0.0.1', port),
-				channel=channel
+			return ConnectionInfo(
+				hostname='127.0.0.1',
+				mode=ConnectionMode.SLAVE,
+				key=channel,
+				port=port
 			)
 			
 		except Exception:

--- a/addon/globalPlugins/remoteClient/secureDesktop.py
+++ b/addon/globalPlugins/remoteClient/secureDesktop.py
@@ -4,7 +4,7 @@ import ssl
 import threading
 import uuid
 from pathlib import Path
-from typing import Any, Optional, Tuple
+from typing import Any, Optional
 
 import shlobj
 from .connection_info import ConnectionInfo, ConnectionMode
@@ -156,7 +156,7 @@ class SecureDesktopHandler:
 		Initialize connection when starting in secure desktop.
 		
 		Returns:
-			SecureDesktopConnection if successful, None if not
+			ConnectionInfo instance if successful, None otherwise
 		"""
 		try:
 			data = json.loads(self.IPCFile.read_text())

--- a/addon/globalPlugins/remoteClient/session.py
+++ b/addon/globalPlugins/remoteClient/session.py
@@ -201,7 +201,7 @@ class SlaveSession(RemoteSession):
 
 	def beep(self, hz: float, length: int, left: int = 50, right: int = 50) -> None:
 		self.transport.send(type=RemoteMessageType.tone, hz=hz,
-		                    length=length, left=left, right=right)
+							length=length, left=left, right=right)
 
 	def playWaveFile(self, **kwargs):
 		"""This machine played a sound, send it to Master machine"""

--- a/addon/globalPlugins/remoteClient/session.py
+++ b/addon/globalPlugins/remoteClient/session.py
@@ -101,6 +101,12 @@ Please either use a different server or upgrade your version of the addon.""")
 		key = self.transport.channel
 		return connection_info.ConnectionInfo(hostname=hostname, port=port, key=key, mode=self.mode)
 
+	def close(self) -> None:
+		self.transport.close()
+		
+	def __del__(self) -> None:
+		self.close()
+
 class SlaveSession(RemoteSession):
 	"""Session that runs on the slave and manages state."""
 

--- a/addon/globalPlugins/remoteClient/transport.py
+++ b/addon/globalPlugins/remoteClient/transport.py
@@ -527,6 +527,17 @@ class RelayTransport(TCPTransport):
         protocol_version: int = PROTOCOL_VERSION,
         insecure: bool = False,
     ) -> None:
+        """Initialize a new RelayTransport instance.
+
+        Args:
+            serializer: Serializer for encoding/decoding messages
+            address: Tuple of (host, port) to connect to
+            timeout: Connection timeout in seconds
+            channel: Optional channel name to join
+            connectionType: Optional connection type identifier
+            protocol_version: Protocol version to use
+            insecure: Whether to skip certificate verification
+        """
         super().__init__(
             address=address, serializer=serializer, timeout=timeout, insecure=insecure
         )
@@ -535,6 +546,25 @@ class RelayTransport(TCPTransport):
         self.connectionType = connectionType
         self.protocol_version = protocol_version
         self.transportConnected.register(self.onConnected)
+
+    @classmethod
+    def create(cls, connection_info: "ConnectionInfo", serializer: Serializer) -> "RelayTransport":
+        """Create a RelayTransport from a ConnectionInfo object.
+        
+        Args:
+            connection_info: ConnectionInfo instance containing connection details
+            serializer: Serializer instance for message encoding/decoding
+            
+        Returns:
+            Configured RelayTransport instance ready for connection
+        """
+        return cls(
+            serializer=serializer,
+            address=(connection_info.hostname, connection_info.port),
+            channel=connection_info.key,
+            connectionType=connection_info.mode.value,
+            insecure=connection_info.insecure
+        )
 
     def onConnected(self) -> None:
         self.send(RemoteMessageType.protocol_version, version=self.protocol_version)

--- a/addon/globalPlugins/remoteClient/transport.py
+++ b/addon/globalPlugins/remoteClient/transport.py
@@ -34,6 +34,7 @@ import wx
 from extensionPoints import Action
 
 from . import configuration
+from .connection_info import ConnectionInfo
 from .protocol import PROTOCOL_VERSION, RemoteMessageType
 from .serializer import Serializer
 from .socket_utils import hostPortToAddress
@@ -548,7 +549,7 @@ class RelayTransport(TCPTransport):
         self.transportConnected.register(self.onConnected)
 
     @classmethod
-    def create(cls, connection_info: "ConnectionInfo", serializer: Serializer) -> "RelayTransport":
+    def create(cls, connection_info: ConnectionInfo, serializer: Serializer) -> "RelayTransport":
         """Create a RelayTransport from a ConnectionInfo object.
         
         Args:


### PR DESCRIPTION
# Extract Remote Client Logic from Global Plugin

Splits NVDA Remote's core functionality into a dedicated `RemoteClient` class, moving most logic out of `GlobalPlugin`. The key changes:

- Created `RemoteClient` to handle all the connection/session/keyboard management that was tangled up in `GlobalPlugin`
- `GlobalPlugin` now just maps NVDA scripts to `RemoteClient` methods and handles initialization
- Switched connection handling to use proper `ConnectionInfo` objects instead of (host, port) tuples
- Added `RelayTransport.create()` factory to centralize transport setup
- Fixed up secure desktop connections to use `ConnectionInfo` 
- Added proper `close()` cleanup to sessions

Made `Menu` smarter about connection states and fixed some menu item lifecycle issues.

The diff looks big but it's mostly moving code - the core functionality remains the same. The main change is that `GlobalPlugin` is now a thin wrapper around `RemoteClient` instead of doing everything itself.
