### PR TITLE
Outbound Remote Extension Points

### DIFF
--- a/addon/globalPlugins/remoteClient/connection_info.py
+++ b/addon/globalPlugins/remoteClient/connection_info.py
@@ -63,11 +63,13 @@ class ConnectionInfo:
 	def _build_url(self, mode: ConnectionMode):
 		# Build URL components
 		netloc = socket_utils.hostPortToAddress((self.hostname, self.port))
-		query = urlencode({
+		params = {
 			'key': self.key,
 			'mode': mode if isinstance(mode, str) else mode.value,
-			'insecure': str(self.insecure).lower()
-		})
+		}
+		if self.insecure:
+			params['insecure'] = 'true'
+		query = urlencode(params)
 		
 		# Use urlunparse for proper URL construction
 		return urlunparse((

--- a/addon/globalPlugins/remoteClient/nvda_patcher.py
+++ b/addon/globalPlugins/remoteClient/nvda_patcher.py
@@ -6,7 +6,6 @@ import inputCore
 import nvwave
 import scriptHandler
 import speech
-import tones
 from speech.extensions import speechCanceled
 
 from . import callback_manager
@@ -36,7 +35,7 @@ class NVDAPatcher(callback_manager.CallbackManager):
 		self.callCallbacks('set_display', displaySize=displaySize)
 
 class NVDASlavePatcher(NVDAPatcher):
-	"""Class to manage patching of synth, tones, nvwave, and braille."""
+	"""Class to manage patching of synth, nvwave, and braille."""
 
 	def __init__(self) -> None:
 		super().__init__()
@@ -51,9 +50,6 @@ class NVDASlavePatcher(NVDAPatcher):
 		speechCanceled.register(self.cancel)
 		self.orig_pauseSpeech = speech.pauseSpeech
 		speech.pauseSpeech = self.pauseSpeech
-
-	def registerTones(self) -> None:
-		tones.decide_beep.register(self.handle_decide_beep)
 
 	def registerNvwave(self) -> None:
 		nvwave.decide_playWaveFile.register(self.handle_decide_playWaveFile)
@@ -70,9 +66,6 @@ class NVDASlavePatcher(NVDAPatcher):
 		speech.pauseSpeech = self.orig_pauseSpeech
 		self.orig_pauseSpeech = None
 
-	def unregisterTones(self):
-		tones.decide_beep.unregister(self.handle_decide_beep)
-
 	def unregisterNvwave(self):
 		nvwave.decide_playWaveFile.unregister(self.handle_decide_playWaveFile)
 
@@ -81,13 +74,11 @@ class NVDASlavePatcher(NVDAPatcher):
 
 	def register(self):
 		self.patchSpeech()
-		self.registerTones()
 		self.registerNvwave()
 		self.registerBraille()
 
 	def unregister(self):
 		self.unpatchSpeech()
-		self.unregisterTones()
 		self.unregisterNvwave()
 		self.unregisterBraille()
 

--- a/addon/globalPlugins/remoteClient/nvda_patcher.py
+++ b/addon/globalPlugins/remoteClient/nvda_patcher.py
@@ -1,10 +1,11 @@
-from typing import Any, List, Optional, Union
+from typing import Any, Optional, Union
 
 import braille
 import brailleInput
 import inputCore
 import scriptHandler
 import speech
+
 from . import callback_manager
 
 
@@ -46,9 +47,6 @@ class NVDASlavePatcher(NVDAPatcher):
 		speech._manager.speak = self.speak
 		self.orig_pauseSpeech = speech.pauseSpeech
 		speech.pauseSpeech = self.pauseSpeech
-	
-	def registerBraille(self) -> None:
-		braille.pre_writeCells.register(self.handle_pre_writeCells)
 
 	def unpatchSpeech(self):
 		if self.origSpeak  is None:
@@ -58,16 +56,11 @@ class NVDASlavePatcher(NVDAPatcher):
 		speech.pauseSpeech = self.orig_pauseSpeech
 		self.orig_pauseSpeech = None
 
-	def unregisterBraille(self):
-		braille.pre_writeCells.unregister(self.handle_pre_writeCells)
-
 	def register(self):
 		self.patchSpeech()
-		self.registerBraille()
 
 	def unregister(self):
 		self.unpatchSpeech()
-		self.unregisterBraille()
 
 	def speak(self, speechSequence: Any, priority: Any) -> None:
 		self.callCallbacks('speak', speechSequence=speechSequence, priority=priority)
@@ -76,10 +69,7 @@ class NVDASlavePatcher(NVDAPatcher):
 	def pauseSpeech(self, switch: bool) -> None:
 		self.callCallbacks('pause_speech', switch=switch)
 		self.orig_pauseSpeech(switch)
-
-	def handle_pre_writeCells(self, cells: List[int]) -> None:
-		self.callCallbacks('display', cells=cells)
-
+		
 class NVDAMasterPatcher(NVDAPatcher):
 	"""Class to manage patching of braille input."""
 

--- a/addon/globalPlugins/remoteClient/session.py
+++ b/addon/globalPlugins/remoteClient/session.py
@@ -23,310 +23,310 @@ addonHandler.initTranslation()
 
 
 EXCLUDED_SPEECH_COMMANDS = (
-    speech.commands.BaseCallbackCommand,
-    # _CancellableSpeechCommands are not designed to be reported and are used internally by NVDA. (#230)
-    speech.commands._CancellableSpeechCommand,
+	speech.commands.BaseCallbackCommand,
+	# _CancellableSpeechCommands are not designed to be reported and are used internally by NVDA. (#230)
+	speech.commands._CancellableSpeechCommand,
 )
 
 
 class RemoteSession:
-    """Base class for a session that runs on either the master or slave machine."""
+	"""Base class for a session that runs on either the master or slave machine."""
 
-    transport: RelayTransport
-    localMachine: local_machine.LocalMachine
-    mode: Optional[connection_info.ConnectionMode] = None
-    patcher: Optional[nvda_patcher.NVDAPatcher]
-    patchCallbacksAdded: bool
+	transport: RelayTransport
+	localMachine: local_machine.LocalMachine
+	mode: Optional[connection_info.ConnectionMode] = None
+	patcher: Optional[nvda_patcher.NVDAPatcher]
+	patchCallbacksAdded: bool
 
-    def __init__(
-        self, localMachine: local_machine.LocalMachine, transport: RelayTransport
-    ) -> None:
-        self.localMachine = localMachine
-        self.patcher = None
-        self.patchCallbacksAdded = False
-        self.transport = transport
-        self.transport.registerInbound(
-            RemoteMessageType.version_mismatch, self.handleVersionMismatch
-        )
-        self.transport.registerInbound(RemoteMessageType.motd, self.handleMOTD)
-        self.transport.registerInbound(
-            RemoteMessageType.set_clipboard_text, self.localMachine.setClipboardText
-        )
-        self.transport.registerInbound(
-            RemoteMessageType.client_joined, self.handleClientConnected
-        )
-        self.transport.registerInbound(
-            RemoteMessageType.client_left, self.handleClientDisconnected
-        )
+	def __init__(
+		self, localMachine: local_machine.LocalMachine, transport: RelayTransport
+	) -> None:
+		self.localMachine = localMachine
+		self.patcher = None
+		self.patchCallbacksAdded = False
+		self.transport = transport
+		self.transport.registerInbound(
+			RemoteMessageType.version_mismatch, self.handleVersionMismatch
+		)
+		self.transport.registerInbound(RemoteMessageType.motd, self.handleMOTD)
+		self.transport.registerInbound(
+			RemoteMessageType.set_clipboard_text, self.localMachine.setClipboardText
+		)
+		self.transport.registerInbound(
+			RemoteMessageType.client_joined, self.handleClientConnected
+		)
+		self.transport.registerInbound(
+			RemoteMessageType.client_left, self.handleClientDisconnected
+		)
 
-    def registerCallbacks(self) -> None:
-        patcher_callbacks = self._getPatcherCallbacks()
-        for event, callback in patcher_callbacks:
-            self.patcher.registerCallback(event, callback)
-        self.patchCallbacksAdded = True
+	def registerCallbacks(self) -> None:
+		patcher_callbacks = self._getPatcherCallbacks()
+		for event, callback in patcher_callbacks:
+			self.patcher.registerCallback(event, callback)
+		self.patchCallbacksAdded = True
 
-    def unregisterCallbacks(self):
-        patcher_callbacks = self._getPatcherCallbacks()
-        for event, callback in patcher_callbacks:
-            self.patcher.unregisterCallback(event, callback)
-        self.patchCallbacksAdded = False
+	def unregisterCallbacks(self):
+		patcher_callbacks = self._getPatcherCallbacks()
+		for event, callback in patcher_callbacks:
+			self.patcher.unregisterCallback(event, callback)
+		self.patchCallbacksAdded = False
 
-    def handleVersionMismatch(self) -> None:
-        # translators: Message for version mismatch
-        message = _("""The version of the relay server which you have connected to is not compatible with this version of the Remote Client.
+	def handleVersionMismatch(self) -> None:
+		# translators: Message for version mismatch
+		message = _("""The version of the relay server which you have connected to is not compatible with this version of the Remote Client.
 Please either use a different server or upgrade your version of the addon.""")
-        ui.message(message)
-        self.transport.close()
+		ui.message(message)
+		self.transport.close()
 
-    def handleMOTD(self, motd: str, force_display=False):
-        if force_display or self.shouldDisplayMotd(motd):
-            gui.messageBox(
-                parent=gui.mainFrame, caption=_("Message of the Day"), message=motd
-            )
+	def handleMOTD(self, motd: str, force_display=False):
+		if force_display or self.shouldDisplayMotd(motd):
+			gui.messageBox(
+				parent=gui.mainFrame, caption=_("Message of the Day"), message=motd
+			)
 
-    def shouldDisplayMotd(self, motd: str) -> bool:
-        conf = configuration.get_config()
-        host, port = self.transport.address
-        host = host.lower()
-        address = "{host}:{port}".format(host=host, port=port)
-        motdBytes = motd.encode("utf-8", errors="surrogatepass")
-        hashed = hashlib.sha1(motdBytes).hexdigest()
-        current = conf["seen_motds"].get(address, "")
-        if current == hashed:
-            return False
-        conf["seen_motds"][address] = hashed
-        conf.write()
-        return True
+	def shouldDisplayMotd(self, motd: str) -> bool:
+		conf = configuration.get_config()
+		host, port = self.transport.address
+		host = host.lower()
+		address = "{host}:{port}".format(host=host, port=port)
+		motdBytes = motd.encode("utf-8", errors="surrogatepass")
+		hashed = hashlib.sha1(motdBytes).hexdigest()
+		current = conf["seen_motds"].get(address, "")
+		if current == hashed:
+			return False
+		conf["seen_motds"][address] = hashed
+		conf.write()
+		return True
 
-    def handleClientConnected(self, client: Optional[Dict[str, Any]] = None) -> None:
-        self.patcher.register()
-        if not self.patchCallbacksAdded:
-            self.registerCallbacks()
-        cues.client_connected()
+	def handleClientConnected(self, client: Optional[Dict[str, Any]] = None) -> None:
+		self.patcher.register()
+		if not self.patchCallbacksAdded:
+			self.registerCallbacks()
+		cues.client_connected()
 
-    def handleClientDisconnected(self, client=None):
-        cues.client_disconnected()
+	def handleClientDisconnected(self, client=None):
+		cues.client_disconnected()
 
-    def getConnectionInfo(self) -> connection_info.ConnectionInfo:
-        hostname, port = self.transport.address
-        key = self.transport.channel
-        return connection_info.ConnectionInfo(
-            hostname=hostname, port=port, key=key, mode=self.mode
-        )
+	def getConnectionInfo(self) -> connection_info.ConnectionInfo:
+		hostname, port = self.transport.address
+		key = self.transport.channel
+		return connection_info.ConnectionInfo(
+			hostname=hostname, port=port, key=key, mode=self.mode
+		)
 
 
 class SlaveSession(RemoteSession):
-    """Session that runs on the slave and manages state."""
+	"""Session that runs on the slave and manages state."""
 
-    mode: connection_info.ConnectionMode = connection_info.ConnectionMode.SLAVE
-    patcher: nvda_patcher.NVDASlavePatcher
-    masters: Dict[int, Dict[str, Any]]
-    masterDisplaySizes: List[int]
+	mode: connection_info.ConnectionMode = connection_info.ConnectionMode.SLAVE
+	patcher: nvda_patcher.NVDASlavePatcher
+	masters: Dict[int, Dict[str, Any]]
+	masterDisplaySizes: List[int]
 
-    def __init__(
-        self, localMachine: local_machine.LocalMachine, transport: RelayTransport
-    ) -> None:
-        super().__init__(localMachine, transport)
-        self.transport.registerInbound(RemoteMessageType.key, self.localMachine.sendKey)
-        self.masters = defaultdict(dict)
-        self.masterDisplaySizes = []
-        self.transport.transportClosing.register(self.handleTransportClosing)
-        self.patcher = nvda_patcher.NVDASlavePatcher()
-        self.transport.registerInbound(
-            RemoteMessageType.channel_joined, self.handleChannelJoined
-        )
-        self.transport.registerInbound(
-            RemoteMessageType.set_braille_info, self.handleBrailleInfo
-        )
-        self.transport.registerInbound(
-            RemoteMessageType.set_display_size, self.setDisplaySize
-        )
-        braille.filter_displaySize.register(self.localMachine.handleFilterDisplaySize)
-        self.transport.registerInbound(
-            RemoteMessageType.braille_input, self.localMachine.brailleInput
-        )
-        self.transport.registerInbound(
-            RemoteMessageType.send_SAS, self.localMachine.sendSAS
-        )
+	def __init__(
+		self, localMachine: local_machine.LocalMachine, transport: RelayTransport
+	) -> None:
+		super().__init__(localMachine, transport)
+		self.transport.registerInbound(RemoteMessageType.key, self.localMachine.sendKey)
+		self.masters = defaultdict(dict)
+		self.masterDisplaySizes = []
+		self.transport.transportClosing.register(self.handleTransportClosing)
+		self.patcher = nvda_patcher.NVDASlavePatcher()
+		self.transport.registerInbound(
+			RemoteMessageType.channel_joined, self.handleChannelJoined
+		)
+		self.transport.registerInbound(
+			RemoteMessageType.set_braille_info, self.handleBrailleInfo
+		)
+		self.transport.registerInbound(
+			RemoteMessageType.set_display_size, self.setDisplaySize
+		)
+		braille.filter_displaySize.register(self.localMachine.handleFilterDisplaySize)
+		self.transport.registerInbound(
+			RemoteMessageType.braille_input, self.localMachine.brailleInput
+		)
+		self.transport.registerInbound(
+			RemoteMessageType.send_SAS, self.localMachine.sendSAS
+		)
 
-    def registerCallbacks(self) -> None:
-        super().registerCallbacks()
-        self.transport.registerOutbound(tones.decide_beep, RemoteMessageType.tone)
-        self.transport.registerOutbound(speechCanceled, RemoteMessageType.cancel)
-        self.transport.registerOutbound(
-            nvwave.decide_playWaveFile, RemoteMessageType.wave
-        )
+	def registerCallbacks(self) -> None:
+		super().registerCallbacks()
+		self.transport.registerOutbound(tones.decide_beep, RemoteMessageType.tone)
+		self.transport.registerOutbound(speechCanceled, RemoteMessageType.cancel)
+		self.transport.registerOutbound(
+			nvwave.decide_playWaveFile, RemoteMessageType.wave
+		)
 
-    def unregisterCallbacks(self) -> None:
-        super().unregisterCallbacks()
-        self.transport.unregisterOutbound(RemoteMessageType.tone)
-        self.transport.unregisterOutbound(RemoteMessageType.cancel)
-        self.transport.unregisterOutbound(RemoteMessageType.wave)
+	def unregisterCallbacks(self) -> None:
+		super().unregisterCallbacks()
+		self.transport.unregisterOutbound(RemoteMessageType.tone)
+		self.transport.unregisterOutbound(RemoteMessageType.cancel)
+		self.transport.unregisterOutbound(RemoteMessageType.wave)
 
-    def handleClientConnected(self, client: Dict[str, Any]) -> None:
-        super().handleClientConnected(client)
-        if client["connection_type"] == "master":
-            self.masters[client["id"]]["active"] = True
+	def handleClientConnected(self, client: Dict[str, Any]) -> None:
+		super().handleClientConnected(client)
+		if client["connection_type"] == "master":
+			self.masters[client["id"]]["active"] = True
 
-    def handleChannelJoined(
-        self,
-        channel: Optional[str] = None,
-        clients: Optional[List[Dict[str, Any]]] = None,
-        origin: Optional[int] = None,
-    ) -> None:
-        if clients is None:
-            clients = []
-        for client in clients:
-            self.handleClientConnected(client)
+	def handleChannelJoined(
+		self,
+		channel: Optional[str] = None,
+		clients: Optional[List[Dict[str, Any]]] = None,
+		origin: Optional[int] = None,
+	) -> None:
+		if clients is None:
+			clients = []
+		for client in clients:
+			self.handleClientConnected(client)
 
-    def handleTransportClosing(self) -> None:
-        self.patcher.unregister()
-        if self.patchCallbacksAdded:
-            self.unregisterCallbacks()
+	def handleTransportClosing(self) -> None:
+		self.patcher.unregister()
+		if self.patchCallbacksAdded:
+			self.unregisterCallbacks()
 
-    def handleTransportDisconnected(self):
-        cues.client_connected()
-        self.patcher.unregister()
+	def handleTransportDisconnected(self):
+		cues.client_connected()
+		self.patcher.unregister()
 
-    def handleClientDisconnected(self, client=None):
-        super().handleClientDisconnected(client)
-        if client["connection_type"] == "master":
-            del self.masters[client["id"]]
-        if not self.masters:
-            self.patcher.unregister()
+	def handleClientDisconnected(self, client=None):
+		super().handleClientDisconnected(client)
+		if client["connection_type"] == "master":
+			del self.masters[client["id"]]
+		if not self.masters:
+			self.patcher.unregister()
 
-    def setDisplaySize(self, sizes=None):
-        self.masterDisplaySizes = (
-            sizes
-            if sizes
-            else [info.get("braille_numCells", 0) for info in self.masters.values()]
-        )
-        self.localMachine.setBrailleDisplay_size(self.masterDisplaySizes)
+	def setDisplaySize(self, sizes=None):
+		self.masterDisplaySizes = (
+			sizes
+			if sizes
+			else [info.get("braille_numCells", 0) for info in self.masters.values()]
+		)
+		self.localMachine.setBrailleDisplay_size(self.masterDisplaySizes)
 
-    def handleBrailleInfo(
-        self,
-        name: Optional[str] = None,
-        numCells: int = 0,
-        origin: Optional[int] = None,
-    ) -> None:
-        if not self.masters.get(origin):
-            return
-        self.masters[origin]["braille_name"] = name
-        self.masters[origin]["braille_numCells"] = numCells
-        self.setDisplaySize()
+	def handleBrailleInfo(
+		self,
+		name: Optional[str] = None,
+		numCells: int = 0,
+		origin: Optional[int] = None,
+	) -> None:
+		if not self.masters.get(origin):
+			return
+		self.masters[origin]["braille_name"] = name
+		self.masters[origin]["braille_numCells"] = numCells
+		self.setDisplaySize()
 
-    def _getPatcherCallbacks(self) -> List[Tuple[str, Callable[..., Any]]]:
-        return (
-            ("speak", self.speak),
-            ("pause_speech", self.pauseSpeech),
-            ("display", self.display),
-            ("set_display", self.setDisplaySize),
-        )
+	def _getPatcherCallbacks(self) -> List[Tuple[str, Callable[..., Any]]]:
+		return (
+			("speak", self.speak),
+			("pause_speech", self.pauseSpeech),
+			("display", self.display),
+			("set_display", self.setDisplaySize),
+		)
 
-    def _filterUnsupportedSpeechCommands(self, speechSequence: List[Any]) -> List[Any]:
-        return list(
-            [
-                item
-                for item in speechSequence
-                if not isinstance(item, EXCLUDED_SPEECH_COMMANDS)
-            ]
-        )
+	def _filterUnsupportedSpeechCommands(self, speechSequence: List[Any]) -> List[Any]:
+		return list(
+			[
+				item
+				for item in speechSequence
+				if not isinstance(item, EXCLUDED_SPEECH_COMMANDS)
+			]
+		)
 
-    def speak(self, speechSequence: List[Any], priority: Optional[str]) -> None:
-        self.transport.send(
-            RemoteMessageType.speak,
-            sequence=self._filterUnsupportedSpeechCommands(speechSequence),
-            priority=priority,
-        )
+	def speak(self, speechSequence: List[Any], priority: Optional[str]) -> None:
+		self.transport.send(
+			RemoteMessageType.speak,
+			sequence=self._filterUnsupportedSpeechCommands(speechSequence),
+			priority=priority,
+		)
 
-    def pauseSpeech(self, switch):
-        self.transport.send(type=RemoteMessageType.pause_speech, switch=switch)
+	def pauseSpeech(self, switch):
+		self.transport.send(type=RemoteMessageType.pause_speech, switch=switch)
 
-    def display(self, cells):
-        # Only send braille data when there are controlling machines with a braille display
-        if self.hasBrailleMasters():
-            self.transport.send(type=RemoteMessageType.display, cells=cells)
+	def display(self, cells):
+		# Only send braille data when there are controlling machines with a braille display
+		if self.hasBrailleMasters():
+			self.transport.send(type=RemoteMessageType.display, cells=cells)
 
-    def hasBrailleMasters(self):
-        return bool([i for i in self.masterDisplaySizes if i > 0])
+	def hasBrailleMasters(self):
+		return bool([i for i in self.masterDisplaySizes if i > 0])
 
 
 class MasterSession(RemoteSession):
-    mode: connection_info.ConnectionMode = connection_info.ConnectionMode.MASTER
-    patcher: nvda_patcher.NVDAMasterPatcher
-    slaves: Dict[int, Dict[str, Any]]
+	mode: connection_info.ConnectionMode = connection_info.ConnectionMode.MASTER
+	patcher: nvda_patcher.NVDAMasterPatcher
+	slaves: Dict[int, Dict[str, Any]]
 
-    def __init__(
-        self, localMachine: local_machine.LocalMachine, transport: RelayTransport
-    ) -> None:
-        super().__init__(localMachine, transport)
-        self.slaves = defaultdict(dict)
-        self.patcher = nvda_patcher.NVDAMasterPatcher()
-        self.transport.registerInbound(RemoteMessageType.speak, self.localMachine.speak)
-        self.transport.registerInbound(
-            RemoteMessageType.cancel, self.localMachine.cancelSpeech
-        )
-        self.transport.registerInbound(
-            RemoteMessageType.pause_speech, self.localMachine.pauseSpeech
-        )
-        self.transport.registerInbound(RemoteMessageType.tone, self.localMachine.beep)
-        self.transport.registerInbound(
-            RemoteMessageType.wave, self.localMachine.playWave
-        )
-        self.transport.registerInbound(
-            RemoteMessageType.display, self.localMachine.display
-        )
-        self.transport.registerInbound(
-            RemoteMessageType.nvda_not_connected, self.handleNVDANotConnected
-        )
-        self.transport.registerInbound(
-            RemoteMessageType.channel_joined, self.handleChannel_joined
-        )
-        self.transport.registerInbound(
-            RemoteMessageType.set_braille_info, self.sendBrailleInfo
-        )
+	def __init__(
+		self, localMachine: local_machine.LocalMachine, transport: RelayTransport
+	) -> None:
+		super().__init__(localMachine, transport)
+		self.slaves = defaultdict(dict)
+		self.patcher = nvda_patcher.NVDAMasterPatcher()
+		self.transport.registerInbound(RemoteMessageType.speak, self.localMachine.speak)
+		self.transport.registerInbound(
+			RemoteMessageType.cancel, self.localMachine.cancelSpeech
+		)
+		self.transport.registerInbound(
+			RemoteMessageType.pause_speech, self.localMachine.pauseSpeech
+		)
+		self.transport.registerInbound(RemoteMessageType.tone, self.localMachine.beep)
+		self.transport.registerInbound(
+			RemoteMessageType.wave, self.localMachine.playWave
+		)
+		self.transport.registerInbound(
+			RemoteMessageType.display, self.localMachine.display
+		)
+		self.transport.registerInbound(
+			RemoteMessageType.nvda_not_connected, self.handleNVDANotConnected
+		)
+		self.transport.registerInbound(
+			RemoteMessageType.channel_joined, self.handleChannel_joined
+		)
+		self.transport.registerInbound(
+			RemoteMessageType.set_braille_info, self.sendBrailleInfo
+		)
 
-    def handleNVDANotConnected(self) -> None:
-        speech.cancelSpeech()
-        ui.message(_("Remote NVDA not connected."))
+	def handleNVDANotConnected(self) -> None:
+		speech.cancelSpeech()
+		ui.message(_("Remote NVDA not connected."))
 
-    def handleChannel_joined(
-        self,
-        channel: Optional[str] = None,
-        clients: Optional[List[Dict[str, Any]]] = None,
-        origin: Optional[int] = None,
-    ) -> None:
-        if clients is None:
-            clients = []
-        for client in clients:
-            self.handleClientConnected(client)
+	def handleChannel_joined(
+		self,
+		channel: Optional[str] = None,
+		clients: Optional[List[Dict[str, Any]]] = None,
+		origin: Optional[int] = None,
+	) -> None:
+		if clients is None:
+			clients = []
+		for client in clients:
+			self.handleClientConnected(client)
 
-    def handleClientConnected(self, client=None):
-        super().handleClientConnected(client)
-        self.sendBrailleInfo()
+	def handleClientConnected(self, client=None):
+		super().handleClientConnected(client)
+		self.sendBrailleInfo()
 
-    def handleClientDisconnected(self, client=None):
-        super().handleClientDisconnected(client)
-        self.patcher.unregister()
-        if self.patchCallbacksAdded:
-            self.unregisterCallbacks()
+	def handleClientDisconnected(self, client=None):
+		super().handleClientDisconnected(client)
+		self.patcher.unregister()
+		if self.patchCallbacksAdded:
+			self.unregisterCallbacks()
 
-    def sendBrailleInfo(
-        self, display: Optional[Any] = None, displaySize: Optional[int] = None
-    ) -> None:
-        if display is None:
-            display = braille.handler.display
-        if displaySize is None:
-            displaySize = braille.handler.displaySize
-        self.transport.send(
-            type="set_braille_info", name=display.name, numCells=displaySize
-        )
+	def sendBrailleInfo(
+		self, display: Optional[Any] = None, displaySize: Optional[int] = None
+	) -> None:
+		if display is None:
+			display = braille.handler.display
+		if displaySize is None:
+			displaySize = braille.handler.displaySize
+		self.transport.send(
+			type="set_braille_info", name=display.name, numCells=displaySize
+		)
 
-    def brailleInput(self) -> None:
-        self.transport.send(type=RemoteMessageType.braille_input)
+	def brailleInput(self) -> None:
+		self.transport.send(type=RemoteMessageType.braille_input)
 
-    def _getPatcherCallbacks(self) -> List[Tuple[str, Callable[..., Any]]]:
-        return (
-            ("braille_input", self.brailleInput),
-            ("set_display", self.sendBrailleInfo),
-        )
+	def _getPatcherCallbacks(self) -> List[Tuple[str, Callable[..., Any]]]:
+		return (
+			("braille_input", self.brailleInput),
+			("set_display", self.sendBrailleInfo),
+		)

--- a/addon/globalPlugins/remoteClient/session.py
+++ b/addon/globalPlugins/remoteClient/session.py
@@ -6,10 +6,12 @@ from typing import Dict, List, Optional, Tuple, Any, Callable
 import addonHandler
 import braille
 import gui
+import nvwave
 import speech
 import tones
 import ui
 from logHandler import log
+from speech.extensions import speechCanceled
 
 from . import configuration, connection_info, cues, local_machine, nvda_patcher
 
@@ -126,11 +128,15 @@ class SlaveSession(RemoteSession):
 	def registerCallbacks(self) -> None:
 		super().registerCallbacks()
 		self.transport.registerOutbound(tones.decide_beep, RemoteMessageType.tone)
+		self.transport.registerOutbound(speechCanceled, RemoteMessageType.cancel)
+		self.transport.registerOutbound(nvwave.decide_playWaveFile, RemoteMessageType.wave)
 
 	def unregisterCallbacks(self) -> None:
 		super().unregisterCallbacks()
-		self.transport.unregisterOutbound(tones.decide_beep)
-		
+		self.transport.unregisterOutbound(RemoteMessageType.tone)
+		self.transport.unregisterOutbound(RemoteMessageType.cancel)
+		self.transport.unregisterOutbound(RemoteMessageType.wave)
+
 	def handleClientConnected(self, client: Dict[str, Any]) -> None:
 		super().handleClientConnected(client)
 		if client['connection_type'] == 'master':

--- a/addon/globalPlugins/remoteClient/session.py
+++ b/addon/globalPlugins/remoteClient/session.py
@@ -232,24 +232,11 @@ class MasterSession(RemoteSession):
 		self.transport.registerInbound(RemoteMessageType.cancel, self.localMachine.cancelSpeech)
 		self.transport.registerInbound(RemoteMessageType.pause_speech, self.localMachine.pauseSpeech)
 		self.transport.registerInbound(RemoteMessageType.tone, self.localMachine.beep)
-		self.transport.registerInbound(RemoteMessageType.wave, self.handlePlayWave)
+		self.transport.registerInbound(RemoteMessageType.wave, self.localMachine.playWave)
 		self.transport.registerInbound(RemoteMessageType.display, self.localMachine.display)
 		self.transport.registerInbound(RemoteMessageType.nvda_not_connected, self.handleNVDANotConnected)
 		self.transport.registerInbound(RemoteMessageType.channel_joined, self.handleChannel_joined)
 		self.transport.registerInbound(RemoteMessageType.set_braille_info, self.sendBrailleInfo)
-
-	def handlePlayWave(self, **kwargs):
-		"""Receive instruction to play a 'wave' from the slave machine
-		This method handles translation (between versions of NVDA Remote) of arguments required for 'msg_wave'
-		"""
-		# Note:
-		# Version 2.2 will send only 'async' in kwargs
-		# Version 2.3 will send 'asynchronous' and 'async' in kwargs
-		if "fileName" not in kwargs:
-			log.error("'fileName' missing from kwargs.")
-			return
-		fileName = kwargs.pop("fileName")
-		self.localMachine.playWave(fileName=fileName)
 
 	def handleNVDANotConnected(self) -> None:
 		speech.cancelSpeech()

--- a/addon/globalPlugins/remoteClient/session.py
+++ b/addon/globalPlugins/remoteClient/session.py
@@ -86,7 +86,7 @@ Please either use a different server or upgrade your version of the addon.""")
 	def shouldDisplayMotd(self, motd: str) -> bool:
 		conf = configuration.get_config()
 		connection = self.getConnectionInfo()
-		address = "{host}:{port}".format(host=connection.host, port=connection.port)
+		address = "{host}:{port}".format(host=connection.hostname, port=connection.port)
 		motdBytes = motd.encode("utf-8", errors="surrogatepass")
 		hashed = hashlib.sha1(motdBytes).hexdigest()
 		current = conf["seen_motds"].get(address, "")

--- a/addon/globalPlugins/remoteClient/session.py
+++ b/addon/globalPlugins/remoteClient/session.py
@@ -16,271 +16,317 @@ from speech.extensions import speechCanceled
 from . import configuration, connection_info, cues, local_machine, nvda_patcher
 
 from .protocol import RemoteMessageType
-from .transport import RelayTransport 
+from .transport import RelayTransport
 
 
 addonHandler.initTranslation()
 
 
 EXCLUDED_SPEECH_COMMANDS = (
-	speech.commands.BaseCallbackCommand,
-	# _CancellableSpeechCommands are not designed to be reported and are used internally by NVDA. (#230)
-		speech.commands._CancellableSpeechCommand,
+    speech.commands.BaseCallbackCommand,
+    # _CancellableSpeechCommands are not designed to be reported and are used internally by NVDA. (#230)
+    speech.commands._CancellableSpeechCommand,
 )
 
 
 class RemoteSession:
-	"""Base class for a session that runs on either the master or slave machine."""
+    """Base class for a session that runs on either the master or slave machine."""
 
-	transport: RelayTransport
-	localMachine: local_machine.LocalMachine
-	mode: Optional[connection_info.ConnectionMode] = None
-	patcher: Optional[nvda_patcher.NVDAPatcher]
-	patchCallbacksAdded: bool
+    transport: RelayTransport
+    localMachine: local_machine.LocalMachine
+    mode: Optional[connection_info.ConnectionMode] = None
+    patcher: Optional[nvda_patcher.NVDAPatcher]
+    patchCallbacksAdded: bool
 
+    def __init__(
+        self, localMachine: local_machine.LocalMachine, transport: RelayTransport
+    ) -> None:
+        self.localMachine = localMachine
+        self.patcher = None
+        self.patchCallbacksAdded = False
+        self.transport = transport
+        self.transport.registerInbound(
+            RemoteMessageType.version_mismatch, self.handleVersionMismatch
+        )
+        self.transport.registerInbound(RemoteMessageType.motd, self.handleMOTD)
+        self.transport.registerInbound(
+            RemoteMessageType.set_clipboard_text, self.localMachine.setClipboardText
+        )
+        self.transport.registerInbound(
+            RemoteMessageType.client_joined, self.handleClientConnected
+        )
+        self.transport.registerInbound(
+            RemoteMessageType.client_left, self.handleClientDisconnected
+        )
 
-	def __init__(self, localMachine: local_machine.LocalMachine, transport: RelayTransport) -> None:
-		self.localMachine = localMachine
-		self.patcher = None
-		self.patchCallbacksAdded = False
-		self.transport = transport
-		self.transport.registerInbound(RemoteMessageType.version_mismatch, self.handleVersionMismatch)
-		self.transport.registerInbound(RemoteMessageType.motd, self.handleMOTD)
-		self.transport.registerInbound(RemoteMessageType.set_clipboard_text, self.localMachine.setClipboardText)
-		self.transport.registerInbound(RemoteMessageType.client_joined, self.handleClientConnected)
-		self.transport.registerInbound(RemoteMessageType.client_left, self.handleClientDisconnected)
+    def registerCallbacks(self) -> None:
+        patcher_callbacks = self._getPatcherCallbacks()
+        for event, callback in patcher_callbacks:
+            self.patcher.registerCallback(event, callback)
+        self.patchCallbacksAdded = True
 
-	def registerCallbacks(self) -> None:
-		patcher_callbacks = self._getPatcherCallbacks()
-		for event, callback in patcher_callbacks:
-			self.patcher.registerCallback(event, callback)
-		self.patchCallbacksAdded = True
+    def unregisterCallbacks(self):
+        patcher_callbacks = self._getPatcherCallbacks()
+        for event, callback in patcher_callbacks:
+            self.patcher.unregisterCallback(event, callback)
+        self.patchCallbacksAdded = False
 
-	def unregisterCallbacks(self):
-		patcher_callbacks = self._getPatcherCallbacks()
-		for event, callback in patcher_callbacks:
-			self.patcher.unregisterCallback(event, callback)
-		self.patchCallbacksAdded = False
-
-	def handleVersionMismatch(self) -> None:
-		# translators: Message for version mismatch
-		message = _("""The version of the relay server which you have connected to is not compatible with this version of the Remote Client.
+    def handleVersionMismatch(self) -> None:
+        # translators: Message for version mismatch
+        message = _("""The version of the relay server which you have connected to is not compatible with this version of the Remote Client.
 Please either use a different server or upgrade your version of the addon.""")
-		ui.message(message)
-		self.transport.close()
+        ui.message(message)
+        self.transport.close()
 
-	def handleMOTD(self, motd: str, force_display=False):
-		if force_display or self.shouldDisplayMotd(motd):
-			gui.messageBox(parent=gui.mainFrame, caption=_(
-				"Message of the Day"), message=motd)
+    def handleMOTD(self, motd: str, force_display=False):
+        if force_display or self.shouldDisplayMotd(motd):
+            gui.messageBox(
+                parent=gui.mainFrame, caption=_("Message of the Day"), message=motd
+            )
 
-	def shouldDisplayMotd(self, motd: str) -> bool:
-		conf = configuration.get_config()
-		host, port = self.transport.address
-		host = host.lower()
-		address = '{host}:{port}'.format(host=host, port=port)
-		motdBytes = motd.encode('utf-8', errors='surrogatepass')
-		hashed = hashlib.sha1(motdBytes).hexdigest()
-		current = conf['seen_motds'].get(address, "")
-		if current == hashed:
-			return False
-		conf['seen_motds'][address] = hashed
-		conf.write()
-		return True
+    def shouldDisplayMotd(self, motd: str) -> bool:
+        conf = configuration.get_config()
+        host, port = self.transport.address
+        host = host.lower()
+        address = "{host}:{port}".format(host=host, port=port)
+        motdBytes = motd.encode("utf-8", errors="surrogatepass")
+        hashed = hashlib.sha1(motdBytes).hexdigest()
+        current = conf["seen_motds"].get(address, "")
+        if current == hashed:
+            return False
+        conf["seen_motds"][address] = hashed
+        conf.write()
+        return True
 
-	def handleClientConnected(self, client: Optional[Dict[str, Any]] = None) -> None:
-		self.patcher.register()
-		if not self.patchCallbacksAdded:
-			self.registerCallbacks()
-		cues.client_connected()
+    def handleClientConnected(self, client: Optional[Dict[str, Any]] = None) -> None:
+        self.patcher.register()
+        if not self.patchCallbacksAdded:
+            self.registerCallbacks()
+        cues.client_connected()
 
-	def handleClientDisconnected(self, client=None):
-		cues.client_disconnected()
+    def handleClientDisconnected(self, client=None):
+        cues.client_disconnected()
 
-	def getConnectionInfo(self) -> connection_info.ConnectionInfo:
-		hostname, port = self.transport.address
-		key = self.transport.channel
-		return connection_info.ConnectionInfo(hostname=hostname, port=port, key=key, mode=self.mode)
+    def getConnectionInfo(self) -> connection_info.ConnectionInfo:
+        hostname, port = self.transport.address
+        key = self.transport.channel
+        return connection_info.ConnectionInfo(
+            hostname=hostname, port=port, key=key, mode=self.mode
+        )
+
 
 class SlaveSession(RemoteSession):
-	"""Session that runs on the slave and manages state."""
+    """Session that runs on the slave and manages state."""
 
-	mode: connection_info.ConnectionMode = connection_info.ConnectionMode.SLAVE
-	patcher: nvda_patcher.NVDASlavePatcher
-	masters: Dict[int, Dict[str, Any]]
-	masterDisplaySizes: List[int]
+    mode: connection_info.ConnectionMode = connection_info.ConnectionMode.SLAVE
+    patcher: nvda_patcher.NVDASlavePatcher
+    masters: Dict[int, Dict[str, Any]]
+    masterDisplaySizes: List[int]
 
-	def __init__(self, localMachine: local_machine.LocalMachine, transport: RelayTransport) -> None:
-		super().__init__(localMachine, transport)
-		self.transport.registerInbound(RemoteMessageType.key, self.localMachine.sendKey)
-		self.masters = defaultdict(dict)
-		self.masterDisplaySizes = []
-		self.transport.transportClosing.register(self.handleTransportClosing)
-		self.patcher = nvda_patcher.NVDASlavePatcher()
-		self.transport.registerInbound(RemoteMessageType.channel_joined, self.handleChannelJoined)
-		self.transport.registerInbound(RemoteMessageType.set_braille_info, self.handleBrailleInfo)
-		self.transport.registerInbound(RemoteMessageType.set_display_size, self.setDisplaySize)
-		braille.filter_displaySize.register(
-			self.localMachine.handleFilterDisplaySize)
-		self.transport.registerInbound(RemoteMessageType.braille_input, self.localMachine.brailleInput)
-		self.transport.registerInbound(RemoteMessageType.send_SAS, self.localMachine.sendSAS)
+    def __init__(
+        self, localMachine: local_machine.LocalMachine, transport: RelayTransport
+    ) -> None:
+        super().__init__(localMachine, transport)
+        self.transport.registerInbound(RemoteMessageType.key, self.localMachine.sendKey)
+        self.masters = defaultdict(dict)
+        self.masterDisplaySizes = []
+        self.transport.transportClosing.register(self.handleTransportClosing)
+        self.patcher = nvda_patcher.NVDASlavePatcher()
+        self.transport.registerInbound(
+            RemoteMessageType.channel_joined, self.handleChannelJoined
+        )
+        self.transport.registerInbound(
+            RemoteMessageType.set_braille_info, self.handleBrailleInfo
+        )
+        self.transport.registerInbound(
+            RemoteMessageType.set_display_size, self.setDisplaySize
+        )
+        braille.filter_displaySize.register(self.localMachine.handleFilterDisplaySize)
+        self.transport.registerInbound(
+            RemoteMessageType.braille_input, self.localMachine.brailleInput
+        )
+        self.transport.registerInbound(
+            RemoteMessageType.send_SAS, self.localMachine.sendSAS
+        )
 
-	def registerCallbacks(self) -> None:
-		super().registerCallbacks()
-		self.transport.registerOutbound(tones.decide_beep, RemoteMessageType.tone)
-		self.transport.registerOutbound(speechCanceled, RemoteMessageType.cancel)
-		self.transport.registerOutbound(nvwave.decide_playWaveFile, RemoteMessageType.wave)
+    def registerCallbacks(self) -> None:
+        super().registerCallbacks()
+        self.transport.registerOutbound(tones.decide_beep, RemoteMessageType.tone)
+        self.transport.registerOutbound(speechCanceled, RemoteMessageType.cancel)
+        self.transport.registerOutbound(
+            nvwave.decide_playWaveFile, RemoteMessageType.wave
+        )
 
-	def unregisterCallbacks(self) -> None:
-		super().unregisterCallbacks()
-		self.transport.unregisterOutbound(RemoteMessageType.tone)
-		self.transport.unregisterOutbound(RemoteMessageType.cancel)
-		self.transport.unregisterOutbound(RemoteMessageType.wave)
+    def unregisterCallbacks(self) -> None:
+        super().unregisterCallbacks()
+        self.transport.unregisterOutbound(RemoteMessageType.tone)
+        self.transport.unregisterOutbound(RemoteMessageType.cancel)
+        self.transport.unregisterOutbound(RemoteMessageType.wave)
 
-	def handleClientConnected(self, client: Dict[str, Any]) -> None:
-		super().handleClientConnected(client)
-		if client['connection_type'] == 'master':
-			self.masters[client['id']]['active'] = True
+    def handleClientConnected(self, client: Dict[str, Any]) -> None:
+        super().handleClientConnected(client)
+        if client["connection_type"] == "master":
+            self.masters[client["id"]]["active"] = True
 
-	def handleChannelJoined(self, channel: Optional[str] = None, clients: Optional[List[Dict[str, Any]]] = None, origin: Optional[int] = None) -> None:
-		if clients is None:
-			clients = []
-		for client in clients:
-			self.handleClientConnected(client)
+    def handleChannelJoined(
+        self,
+        channel: Optional[str] = None,
+        clients: Optional[List[Dict[str, Any]]] = None,
+        origin: Optional[int] = None,
+    ) -> None:
+        if clients is None:
+            clients = []
+        for client in clients:
+            self.handleClientConnected(client)
 
-	def handleTransportClosing(self) -> None:
-		self.patcher.unregister()
-		if self.patchCallbacksAdded:
-			self.unregisterCallbacks()
+    def handleTransportClosing(self) -> None:
+        self.patcher.unregister()
+        if self.patchCallbacksAdded:
+            self.unregisterCallbacks()
 
-	def handleTransportDisconnected(self):
-		cues.client_connected()
-		self.patcher.unregister()
+    def handleTransportDisconnected(self):
+        cues.client_connected()
+        self.patcher.unregister()
 
-	def handleClientDisconnected(self, client=None):
-		super().handleClientDisconnected(client)
-		if client['connection_type'] == 'master':
-			del self.masters[client['id']]
-		if not self.masters:
-			self.patcher.unregister()
+    def handleClientDisconnected(self, client=None):
+        super().handleClientDisconnected(client)
+        if client["connection_type"] == "master":
+            del self.masters[client["id"]]
+        if not self.masters:
+            self.patcher.unregister()
 
-	def setDisplaySize(self, sizes=None):
-		self.masterDisplaySizes = sizes if sizes else [
-			info.get("braille_numCells", 0) for info in self.masters.values()]
-		self.localMachine.setBrailleDisplay_size(self.masterDisplaySizes)
+    def setDisplaySize(self, sizes=None):
+        self.masterDisplaySizes = (
+            sizes
+            if sizes
+            else [info.get("braille_numCells", 0) for info in self.masters.values()]
+        )
+        self.localMachine.setBrailleDisplay_size(self.masterDisplaySizes)
 
-	def handleBrailleInfo(self, name: Optional[str] = None, numCells: int = 0, origin: Optional[int] = None) -> None:
-		if not self.masters.get(origin):
-			return
-		self.masters[origin]['braille_name'] = name
-		self.masters[origin]['braille_numCells'] = numCells
-		self.setDisplaySize()
+    def handleBrailleInfo(
+        self,
+        name: Optional[str] = None,
+        numCells: int = 0,
+        origin: Optional[int] = None,
+    ) -> None:
+        if not self.masters.get(origin):
+            return
+        self.masters[origin]["braille_name"] = name
+        self.masters[origin]["braille_numCells"] = numCells
+        self.setDisplaySize()
 
-	def _getPatcherCallbacks(self) -> List[Tuple[str, Callable[..., Any]]]:
-		return (
-			('speak', self.speak),
-				('beep', self.beep),
-				('wave', self.playWaveFile),
-				('cancel_speech', self.cancelSpeech),
-				('pause_speech', self.pauseSpeech),
-				('display', self.display),
-				('set_display', self.setDisplaySize)
-		)
-	
-	def _filterUnsupportedSpeechCommands(self, speechSequence: List[Any]) -> List[Any]:
-		return list([
-			item for item in speechSequence
-			if not isinstance(item, EXCLUDED_SPEECH_COMMANDS)
-		])
+    def _getPatcherCallbacks(self) -> List[Tuple[str, Callable[..., Any]]]:
+        return (
+            ("speak", self.speak),
+            ("pause_speech", self.pauseSpeech),
+            ("display", self.display),
+            ("set_display", self.setDisplaySize),
+        )
 
-	def speak(self, speechSequence: List[Any], priority: Optional[str]) -> None:
-		self.transport.send(RemoteMessageType.speak,
-							sequence=self._filterUnsupportedSpeechCommands(
-								speechSequence),
-							priority=priority
-							)
+    def _filterUnsupportedSpeechCommands(self, speechSequence: List[Any]) -> List[Any]:
+        return list(
+            [
+                item
+                for item in speechSequence
+                if not isinstance(item, EXCLUDED_SPEECH_COMMANDS)
+            ]
+        )
 
-	def cancelSpeech(self):
-		self.transport.send(type=RemoteMessageType.cancel)
+    def speak(self, speechSequence: List[Any], priority: Optional[str]) -> None:
+        self.transport.send(
+            RemoteMessageType.speak,
+            sequence=self._filterUnsupportedSpeechCommands(speechSequence),
+            priority=priority,
+        )
 
-	def pauseSpeech(self, switch):
-		self.transport.send(type=RemoteMessageType.pause_speech, switch=switch)
+    def pauseSpeech(self, switch):
+        self.transport.send(type=RemoteMessageType.pause_speech, switch=switch)
 
-	def beep(self, hz: float, length: int, left: int = 50, right: int = 50) -> None:
-		self.transport.send(type=RemoteMessageType.tone, hz=hz,
-		                    length=length, left=left, right=right)
+    def display(self, cells):
+        # Only send braille data when there are controlling machines with a braille display
+        if self.hasBrailleMasters():
+            self.transport.send(type=RemoteMessageType.display, cells=cells)
 
-	def playWaveFile(self, **kwargs):
-		"""This machine played a sound, send it to Master machine"""
-		kwargs.update({
-			# nvWave.playWaveFile should always be asynchronous when called from NVDA remote, so always send 'True'
-				# Version 2.2 requires 'async' keyword.
-				'async': True,
-				# Version 2.3 onwards. Not currently used, but matches arguments for nvWave.playWaveFile.
-				# Including it allows for forward compatibility if requirements change.
-				'asynchronous': True,
-		})
-		self.transport.send(type=RemoteMessageType.wave)
-
-	def display(self, cells):
-		# Only send braille data when there are controlling machines with a braille display
-		if self.hasBrailleMasters():
-			self.transport.send(type=RemoteMessageType.display, cells=cells)
-
-	def hasBrailleMasters(self):
-		return bool([i for i in self.masterDisplaySizes if i > 0])
+    def hasBrailleMasters(self):
+        return bool([i for i in self.masterDisplaySizes if i > 0])
 
 
 class MasterSession(RemoteSession):
+    mode: connection_info.ConnectionMode = connection_info.ConnectionMode.MASTER
+    patcher: nvda_patcher.NVDAMasterPatcher
+    slaves: Dict[int, Dict[str, Any]]
 
-	mode: connection_info.ConnectionMode = connection_info.ConnectionMode.MASTER
-	patcher: nvda_patcher.NVDAMasterPatcher
-	slaves: Dict[int, Dict[str, Any]]
+    def __init__(
+        self, localMachine: local_machine.LocalMachine, transport: RelayTransport
+    ) -> None:
+        super().__init__(localMachine, transport)
+        self.slaves = defaultdict(dict)
+        self.patcher = nvda_patcher.NVDAMasterPatcher()
+        self.transport.registerInbound(RemoteMessageType.speak, self.localMachine.speak)
+        self.transport.registerInbound(
+            RemoteMessageType.cancel, self.localMachine.cancelSpeech
+        )
+        self.transport.registerInbound(
+            RemoteMessageType.pause_speech, self.localMachine.pauseSpeech
+        )
+        self.transport.registerInbound(RemoteMessageType.tone, self.localMachine.beep)
+        self.transport.registerInbound(
+            RemoteMessageType.wave, self.localMachine.playWave
+        )
+        self.transport.registerInbound(
+            RemoteMessageType.display, self.localMachine.display
+        )
+        self.transport.registerInbound(
+            RemoteMessageType.nvda_not_connected, self.handleNVDANotConnected
+        )
+        self.transport.registerInbound(
+            RemoteMessageType.channel_joined, self.handleChannel_joined
+        )
+        self.transport.registerInbound(
+            RemoteMessageType.set_braille_info, self.sendBrailleInfo
+        )
 
-	def __init__(self, localMachine: local_machine.LocalMachine, transport: RelayTransport) -> None:
-		super().__init__(localMachine, transport)
-		self.slaves = defaultdict(dict)
-		self.patcher = nvda_patcher.NVDAMasterPatcher()
-		self.transport.registerInbound(RemoteMessageType.speak, self.localMachine.speak)
-		self.transport.registerInbound(RemoteMessageType.cancel, self.localMachine.cancelSpeech)
-		self.transport.registerInbound(RemoteMessageType.pause_speech, self.localMachine.pauseSpeech)
-		self.transport.registerInbound(RemoteMessageType.tone, self.localMachine.beep)
-		self.transport.registerInbound(RemoteMessageType.wave, self.localMachine.playWave)
-		self.transport.registerInbound(RemoteMessageType.display, self.localMachine.display)
-		self.transport.registerInbound(RemoteMessageType.nvda_not_connected, self.handleNVDANotConnected)
-		self.transport.registerInbound(RemoteMessageType.channel_joined, self.handleChannel_joined)
-		self.transport.registerInbound(RemoteMessageType.set_braille_info, self.sendBrailleInfo)
+    def handleNVDANotConnected(self) -> None:
+        speech.cancelSpeech()
+        ui.message(_("Remote NVDA not connected."))
 
-	def handleNVDANotConnected(self) -> None:
-		speech.cancelSpeech()
-		ui.message(_("Remote NVDA not connected."))
+    def handleChannel_joined(
+        self,
+        channel: Optional[str] = None,
+        clients: Optional[List[Dict[str, Any]]] = None,
+        origin: Optional[int] = None,
+    ) -> None:
+        if clients is None:
+            clients = []
+        for client in clients:
+            self.handleClientConnected(client)
 
-	def handleChannel_joined(self, channel: Optional[str] = None, clients: Optional[List[Dict[str, Any]]] = None, origin: Optional[int] = None) -> None:
-		if clients is None:
-			clients = []
-		for client in clients:
-			self.handleClientConnected(client)
+    def handleClientConnected(self, client=None):
+        super().handleClientConnected(client)
+        self.sendBrailleInfo()
 
-	def handleClientConnected(self, client=None):
-		super().handleClientConnected(client)
-		self.sendBrailleInfo()
+    def handleClientDisconnected(self, client=None):
+        super().handleClientDisconnected(client)
+        self.patcher.unregister()
+        if self.patchCallbacksAdded:
+            self.unregisterCallbacks()
 
-	def handleClientDisconnected(self, client=None):
-		super().handleClientDisconnected(client)
-		self.patcher.unregister()
-		if self.patchCallbacksAdded:
-			self.unregisterCallbacks()
+    def sendBrailleInfo(
+        self, display: Optional[Any] = None, displaySize: Optional[int] = None
+    ) -> None:
+        if display is None:
+            display = braille.handler.display
+        if displaySize is None:
+            displaySize = braille.handler.displaySize
+        self.transport.send(
+            type="set_braille_info", name=display.name, numCells=displaySize
+        )
 
-	def sendBrailleInfo(self, display: Optional[Any] = None, displaySize: Optional[int] = None) -> None:
-		if display is None:
-			display = braille.handler.display
-		if displaySize is None:
-			displaySize = braille.handler.displaySize
-		self.transport.send(type="set_braille_info",
-							name=display.name, numCells=displaySize)
+    def brailleInput(self) -> None:
+        self.transport.send(type=RemoteMessageType.braille_input)
 
-	def brailleInput(self) -> None:
-		self.transport.send(type=RemoteMessageType.braille_input)
-
-	def _getPatcherCallbacks(self) -> List[Tuple[str, Callable[..., Any]]]:
-		return 		(('braille_input', self.brailleInput), ('set_display', self.sendBrailleInfo))
+    def _getPatcherCallbacks(self) -> List[Tuple[str, Callable[..., Any]]]:
+        return (
+            ("braille_input", self.brailleInput),
+            ("set_display", self.sendBrailleInfo),
+        )

--- a/addon/globalPlugins/remoteClient/transport.py
+++ b/addon/globalPlugins/remoteClient/transport.py
@@ -53,9 +53,10 @@ class RemoteExtensionPoint:
         if self.filter:
             kwargs = self.filter(*args, **kwargs)
         self.transport.send(self.messageType, **kwargs)
+        return True
 
-        def register(self, ttransport: "Transport"):
-            self.transport = ttransport
+        def register(self, transport: "Transport"):
+            self.transport = transport
             self.extensionPoint.register(self.remoteBridge)
 
         def unregister(self):

--- a/addon/globalPlugins/remoteClient/transport.py
+++ b/addon/globalPlugins/remoteClient/transport.py
@@ -3,17 +3,17 @@
 This module provides the core networking functionality for NVDA Remote.
 
 Classes:
-    Transport: Base class defining the transport interface
-    TCPTransport: Implementation of secure TCP socket transport
-    RelayTransport: Extended TCP transport for relay server connections
-    ConnectorThread: Helper class for connection management
+	Transport: Base class defining the transport interface
+	TCPTransport: Implementation of secure TCP socket transport
+	RelayTransport: Extended TCP transport for relay server connections
+	ConnectorThread: Helper class for connection management
 
 The transport layer handles:
-    * Secure socket connections with SSL/TLS
-    * Message serialization and deserialization
-    * Connection management and reconnection
-    * Event notifications for connection state changes
-    * Message routing based on RemoteMessageType enum
+	* Secure socket connections with SSL/TLS
+	* Message serialization and deserialization
+	* Connection management and reconnection
+	* Event notifications for connection state changes
+	* Message routing based on RemoteMessageType enum
 
 All network operations run in background threads, while message handlers
 are called on the main wxPython thread for thread-safety.
@@ -45,670 +45,670 @@ log = getLogger("transport")
 
 @dataclass
 class RemoteExtensionPoint:
-    """Bridges local extension points to remote message sending.
-    
-    This class connects local NVDA extension points to the remote transport layer,
-    allowing local events to trigger remote messages with optional argument transformation.
-    
-    Args:
-        extensionPoint: The NVDA extension point to bridge
-        messageType: The remote message type to send
-        filter: Optional function to transform arguments before sending
-        transport: The transport instance (set on registration)
-        
-    The filter function, if provided, should take (*args, **kwargs) and return
-    a new kwargs dict to be sent in the message.
-    """
-    extensionPoint: HandlerRegistrar
-    messageType: RemoteMessageType  
-    filter: Optional[Callable[..., Dict[str, Any]]] = None
-    transport: Optional["Transport"] = None
+	"""Bridges local extension points to remote message sending.
+	
+	This class connects local NVDA extension points to the remote transport layer,
+	allowing local events to trigger remote messages with optional argument transformation.
+	
+	Args:
+		extensionPoint: The NVDA extension point to bridge
+		messageType: The remote message type to send
+		filter: Optional function to transform arguments before sending
+		transport: The transport instance (set on registration)
+		
+	The filter function, if provided, should take (*args, **kwargs) and return
+	a new kwargs dict to be sent in the message.
+	"""
+	extensionPoint: HandlerRegistrar
+	messageType: RemoteMessageType  
+	filter: Optional[Callable[..., Dict[str, Any]]] = None
+	transport: Optional["Transport"] = None
 
-    def remoteBridge(self, *args: Any, **kwargs: Any) -> bool:
-        """Bridge function that gets registered to the extension point.
-        
-        Handles calling the filter if present and sending the message.
-        Always returns True to allow other handlers to process the event.
-        """
-        if self.filter:
-            # Filter should transform args/kwargs into just the kwargs needed for the message
-            kwargs = self.filter(*args, **kwargs)
-        if self.transport:
-            self.transport.send(self.messageType, **kwargs)
-        return True
+	def remoteBridge(self, *args: Any, **kwargs: Any) -> bool:
+		"""Bridge function that gets registered to the extension point.
+		
+		Handles calling the filter if present and sending the message.
+		Always returns True to allow other handlers to process the event.
+		"""
+		if self.filter:
+			# Filter should transform args/kwargs into just the kwargs needed for the message
+			kwargs = self.filter(*args, **kwargs)
+		if self.transport:
+			self.transport.send(self.messageType, **kwargs)
+		return True
 
-    def register(self, transport: "Transport") -> None:
-        """Register this bridge with a transport and the extension point."""
-        self.transport = transport
-        self.extensionPoint.register(self.remoteBridge)
+	def register(self, transport: "Transport") -> None:
+		"""Register this bridge with a transport and the extension point."""
+		self.transport = transport
+		self.extensionPoint.register(self.remoteBridge)
 
-    def unregister(self) -> None:
-        """Unregister this bridge from the extension point."""
-        self.extensionPoint.unregister(self.remoteBridge)
+	def unregister(self) -> None:
+		"""Unregister this bridge from the extension point."""
+		self.extensionPoint.unregister(self.remoteBridge)
 
 
 class Transport:
-    """Base class defining the network transport interface for NVDA Remote.
+	"""Base class defining the network transport interface for NVDA Remote.
 
-    This abstract base class defines the interface that all network transports must implement.
-    It provides core functionality for secure message passing, connection management,
-    and event handling between NVDA instances.
+	This abstract base class defines the interface that all network transports must implement.
+	It provides core functionality for secure message passing, connection management,
+	and event handling between NVDA instances.
 
-    The Transport class handles:
+	The Transport class handles:
 
-    * Message serialization and routing using a pluggable serializer
-    * Connection state management and event notifications
-    * Registration of message type handlers
-    * Thread-safe connection events
+	* Message serialization and routing using a pluggable serializer
+	* Connection state management and event notifications
+	* Registration of message type handlers
+	* Thread-safe connection events
 
-    To implement a new transport:
+	To implement a new transport:
 
-    1. Subclass Transport
-    2. Implement connection logic in run()
-    3. Call onTransportConnected() when connected
-    4. Use send() to transmit messages
-    5. Call appropriate event notifications
+	1. Subclass Transport
+	2. Implement connection logic in run()
+	3. Call onTransportConnected() when connected
+	4. Use send() to transmit messages
+	5. Call appropriate event notifications
 
-    Example:
-        >>> serializer = JSONSerializer()
-        >>> transport = TCPTransport(serializer, ("localhost", 8090))
-        >>> transport.registerInbound(RemoteMessageType.key, handle_key)
-        >>> transport.run()
+	Example:
+		>>> serializer = JSONSerializer()
+		>>> transport = TCPTransport(serializer, ("localhost", 8090))
+		>>> transport.registerInbound(RemoteMessageType.key, handle_key)
+		>>> transport.run()
 
-    Args:
-        serializer: The serializer instance to use for message encoding/decoding
+	Args:
+		serializer: The serializer instance to use for message encoding/decoding
 
-    Attributes:
-        connected (bool): True if transport has an active connection
-        successful_connects (int): Counter of successful connection attempts
-        connected_event (threading.Event): Event that is set when connected
-        serializer (Serializer): The message serializer instance
-        inboundHandlers (Dict[RemoteMessageType, Callable]): Registered message handlers
+	Attributes:
+		connected (bool): True if transport has an active connection
+		successful_connects (int): Counter of successful connection attempts
+		connected_event (threading.Event): Event that is set when connected
+		serializer (Serializer): The message serializer instance
+		inboundHandlers (Dict[RemoteMessageType, Callable]): Registered message handlers
 
-    Events:
-        transportConnected: Fired after connection is established and ready
-        transportDisconnected: Fired when existing connection is lost
-        transportCertificateAuthenticationFailed: Fired when SSL certificate validation fails
-        transportConnectionFailed: Fired when a connection attempt fails
-        transportClosing: Fired before transport is shut down
-    """
+	Events:
+		transportConnected: Fired after connection is established and ready
+		transportDisconnected: Fired when existing connection is lost
+		transportCertificateAuthenticationFailed: Fired when SSL certificate validation fails
+		transportConnectionFailed: Fired when a connection attempt fails
+		transportClosing: Fired before transport is shut down
+	"""
 
-    connected: bool
-    successfulConnects: int
-    connectedEvent: threading.Event
-    serializer: Serializer
+	connected: bool
+	successfulConnects: int
+	connectedEvent: threading.Event
+	serializer: Serializer
 
-    def __init__(self, serializer: Serializer) -> None:
-        self.serializer = serializer
-        self.connected = False
-        self.successfulConnects = 0
-        self.connectedEvent = threading.Event()
-        # iterate over all the message types and create a dictionary of handlers mapping to Action()
-        self.inboundHandlers: Dict[RemoteMessageType, Callable] = {
-            msg: Action() for msg in RemoteMessageType
-        }
-        self.outboundHandlers: Dict[RemoteMessageType, RemoteExtensionPoint] = {}
-        self.transportConnected = Action()
-        """
+	def __init__(self, serializer: Serializer) -> None:
+		self.serializer = serializer
+		self.connected = False
+		self.successfulConnects = 0
+		self.connectedEvent = threading.Event()
+		# iterate over all the message types and create a dictionary of handlers mapping to Action()
+		self.inboundHandlers: Dict[RemoteMessageType, Callable] = {
+			msg: Action() for msg in RemoteMessageType
+		}
+		self.outboundHandlers: Dict[RemoteMessageType, RemoteExtensionPoint] = {}
+		self.transportConnected = Action()
+		"""
 		Notifies when the transport is connected
 		"""
-        self.transportDisconnected = Action()
-        """
+		self.transportDisconnected = Action()
+		"""
 		Notifies when the transport is disconnected
 		"""
-        self.transportCertificateAuthenticationFailed = Action()
-        """
+		self.transportCertificateAuthenticationFailed = Action()
+		"""
 		Notifies when the transport fails to authenticate the certificate
 		"""
-        self.transportConnectionFailed = Action()
-        """
+		self.transportConnectionFailed = Action()
+		"""
 		Notifies when the transport fails to connect
 		"""
-        self.transportClosing = Action()
-        """
+		self.transportClosing = Action()
+		"""
 		Notifies when the transport is closing
 		"""
 
-    def onTransportConnected(self) -> None:
-        """Handle successful transport connection.
+	def onTransportConnected(self) -> None:
+		"""Handle successful transport connection.
 
-        Called internally when a connection is established. Updates connection state,
-        increments successful connection counter, and notifies listeners.
+		Called internally when a connection is established. Updates connection state,
+		increments successful connection counter, and notifies listeners.
 
-        This method:
-        1. Increments successful connection counter
-        2. Sets connected flag to True
-        3. Sets the connected event
-        4. Notifies transportConnected listeners
-        """
-        self.successfulConnects += 1
-        self.connected = True
-        self.connectedEvent.set()
-        self.transportConnected.notify()
+		This method:
+		1. Increments successful connection counter
+		2. Sets connected flag to True
+		3. Sets the connected event
+		4. Notifies transportConnected listeners
+		"""
+		self.successfulConnects += 1
+		self.connected = True
+		self.connectedEvent.set()
+		self.transportConnected.notify()
 
-    def registerInbound(self, type: RemoteMessageType, handler: Callable) -> None:
-        """Register a handler for incoming messages of a specific type.
+	def registerInbound(self, type: RemoteMessageType, handler: Callable) -> None:
+		"""Register a handler for incoming messages of a specific type.
 
-        Adds a callback function to handle messages of the specified RemoteMessageType.
-        Multiple handlers can be registered for the same message type.
+		Adds a callback function to handle messages of the specified RemoteMessageType.
+		Multiple handlers can be registered for the same message type.
 
-        Args:
-                type (RemoteMessageType): The message type to handle
-                handler (Callable): Callback function to process messages of this type.
-                        Will be called with the message payload as kwargs.
+		Args:
+				type (RemoteMessageType): The message type to handle
+				handler (Callable): Callback function to process messages of this type.
+						Will be called with the message payload as kwargs.
 
-        Example:
-                >>> def handle_keypress(key_code, pressed):
-                ...     print(f"Key {key_code} {'pressed' if pressed else 'released'}")
-                >>> transport.registerInbound(RemoteMessageType.key_press, handle_keypress)
+		Example:
+				>>> def handle_keypress(key_code, pressed):
+				...     print(f"Key {key_code} {'pressed' if pressed else 'released'}")
+				>>> transport.registerInbound(RemoteMessageType.key_press, handle_keypress)
 
-        Note:
-                Handlers are called asynchronously on the wx main thread via wx.CallAfter
-        """
-        self.inboundHandlers[type].register(handler)
+		Note:
+				Handlers are called asynchronously on the wx main thread via wx.CallAfter
+		"""
+		self.inboundHandlers[type].register(handler)
 
-    def unregisterInbound(self, type: RemoteMessageType, handler: Callable) -> None:
-        """Remove a previously registered message handler.
+	def unregisterInbound(self, type: RemoteMessageType, handler: Callable) -> None:
+		"""Remove a previously registered message handler.
 
-        Removes a specific handler function from the list of handlers for a message type.
-        If the handler was not previously registered, this is a no-op.
+		Removes a specific handler function from the list of handlers for a message type.
+		If the handler was not previously registered, this is a no-op.
 
-        Args:
-                type (RemoteMessageType): The message type to unregister from
-                handler (Callable): The handler function to remove
+		Args:
+				type (RemoteMessageType): The message type to unregister from
+				handler (Callable): The handler function to remove
 
-        Example:
-                >>> transport.unregisterInbound(RemoteMessageType.key_press, handle_keypress)
+		Example:
+				>>> transport.unregisterInbound(RemoteMessageType.key_press, handle_keypress)
 
-        Note:
-                Must pass the exact same handler function that was previously registered
-        """
-        self.inboundHandlers[type].unregister(handler)
+		Note:
+				Must pass the exact same handler function that was previously registered
+		"""
+		self.inboundHandlers[type].unregister(handler)
 
-    def registerOutbound(
-        self,
-        extensionPoint: HandlerRegistrar,
-        messageType: RemoteMessageType,
-        filter: Optional[Callable] = None,
-    ):
-        """Register an extension point to a message type.
+	def registerOutbound(
+		self,
+		extensionPoint: HandlerRegistrar,
+		messageType: RemoteMessageType,
+		filter: Optional[Callable] = None,
+	):
+		"""Register an extension point to a message type.
 
-        Args:
-            extensionPoint (HandlerRegistrar): The extension point to register
-            messageType (RemoteMessageType): The message type to register the extension point to
-            filter (Optional[Callable], optional): A filter function to apply to the message before sending. Defaults to None.
-        """
-        remoteExtension = RemoteExtensionPoint(
-            extensionPoint=extensionPoint, messageType=messageType, filter=filter
-        )
-        remoteExtension.register(self)
-        self.outboundHandlers[messageType] = remoteExtension
+		Args:
+			extensionPoint (HandlerRegistrar): The extension point to register
+			messageType (RemoteMessageType): The message type to register the extension point to
+			filter (Optional[Callable], optional): A filter function to apply to the message before sending. Defaults to None.
+		"""
+		remoteExtension = RemoteExtensionPoint(
+			extensionPoint=extensionPoint, messageType=messageType, filter=filter
+		)
+		remoteExtension.register(self)
+		self.outboundHandlers[messageType] = remoteExtension
 
-    def unregisterOutbound(self, messageType: RemoteMessageType):
-        """Unregister an extension point from a message type.
+	def unregisterOutbound(self, messageType: RemoteMessageType):
+		"""Unregister an extension point from a message type.
 
-        Args:
-            messageType (RemoteMessageType): The message type to unregister the extension point from
-        """
-        self.outboundHandlers[messageType].unregister()
-        del self.outboundHandlers[messageType]
+		Args:
+			messageType (RemoteMessageType): The message type to unregister the extension point from
+		"""
+		self.outboundHandlers[messageType].unregister()
+		del self.outboundHandlers[messageType]
 
 
 
 class TCPTransport(Transport):
-    """Secure TCP socket transport implementation.
+	"""Secure TCP socket transport implementation.
 
-    This class implements the Transport interface using TCP sockets with SSL/TLS
-    encryption. It handles connection establishment, data transfer, and connection
-    lifecycle management.
+	This class implements the Transport interface using TCP sockets with SSL/TLS
+	encryption. It handles connection establishment, data transfer, and connection
+	lifecycle management.
 
-    Args:
-        serializer (Serializer): Message serializer instance
-        address (Tuple[str, int]): Remote address to connect to
-        timeout (int, optional): Connection timeout in seconds. Defaults to 0.
-        insecure (bool, optional): Skip certificate verification. Defaults to False.
+	Args:
+		serializer (Serializer): Message serializer instance
+		address (Tuple[str, int]): Remote address to connect to
+		timeout (int, optional): Connection timeout in seconds. Defaults to 0.
+		insecure (bool, optional): Skip certificate verification. Defaults to False.
 
-    Attributes:
-        buffer (bytes): Buffer for incomplete received data
-        closed (bool): Whether transport is closed
-        queue (Queue[Optional[bytes]]): Queue of outbound messages
-        insecure (bool): Whether to skip certificate verification
-        address (Tuple[str, int]): Remote address to connect to
-        timeout (int): Connection timeout in seconds
-        serverSock (Optional[ssl.SSLSocket]): The SSL socket connection
-        serverSockLock (threading.Lock): Lock for thread-safe socket access
-        queueThread (Optional[threading.Thread]): Thread handling outbound messages
-        reconnectorThread (ConnectorThread): Thread managing reconnection
-    """
+	Attributes:
+		buffer (bytes): Buffer for incomplete received data
+		closed (bool): Whether transport is closed
+		queue (Queue[Optional[bytes]]): Queue of outbound messages
+		insecure (bool): Whether to skip certificate verification
+		address (Tuple[str, int]): Remote address to connect to
+		timeout (int): Connection timeout in seconds
+		serverSock (Optional[ssl.SSLSocket]): The SSL socket connection
+		serverSockLock (threading.Lock): Lock for thread-safe socket access
+		queueThread (Optional[threading.Thread]): Thread handling outbound messages
+		reconnectorThread (ConnectorThread): Thread managing reconnection
+	"""
 
-    buffer: bytes
-    closed: bool
-    queue: Queue[Optional[bytes]]
-    insecure: bool
-    serverSockLock: threading.Lock
-    address: Tuple[str, int]
-    serverSock: Optional[ssl.SSLSocket]
-    queueThread: Optional[threading.Thread]
-    timeout: int
-    reconnectorThread: "ConnectorThread"
-    lastFailFingerprint: Optional[str]
+	buffer: bytes
+	closed: bool
+	queue: Queue[Optional[bytes]]
+	insecure: bool
+	serverSockLock: threading.Lock
+	address: Tuple[str, int]
+	serverSock: Optional[ssl.SSLSocket]
+	queueThread: Optional[threading.Thread]
+	timeout: int
+	reconnectorThread: "ConnectorThread"
+	lastFailFingerprint: Optional[str]
 
-    def __init__(
-        self,
-        serializer: Serializer,
-        address: Tuple[str, int],
-        timeout: int = 0,
-        insecure: bool = False,
-    ) -> None:
-        super().__init__(serializer=serializer)
-        self.closed = False
-        # Buffer to hold partially received data
-        self.buffer = b""
-        self.queue = Queue()
-        self.address = address
-        self.serverSock = None
-        # Reading/writing from an SSL socket is not thread safe.
-        # See https://bugs.python.org/issue41597#msg375692
-        # Guard access to the socket with a lock.
-        self.serverSockLock = threading.Lock()
-        self.queueThread = None
-        self.timeout = timeout
-        self.reconnectorThread = ConnectorThread(self)
-        self.insecure = insecure
+	def __init__(
+		self,
+		serializer: Serializer,
+		address: Tuple[str, int],
+		timeout: int = 0,
+		insecure: bool = False,
+	) -> None:
+		super().__init__(serializer=serializer)
+		self.closed = False
+		# Buffer to hold partially received data
+		self.buffer = b""
+		self.queue = Queue()
+		self.address = address
+		self.serverSock = None
+		# Reading/writing from an SSL socket is not thread safe.
+		# See https://bugs.python.org/issue41597#msg375692
+		# Guard access to the socket with a lock.
+		self.serverSockLock = threading.Lock()
+		self.queueThread = None
+		self.timeout = timeout
+		self.reconnectorThread = ConnectorThread(self)
+		self.insecure = insecure
 
-    def run(self) -> None:
-        self.closed = False
-        try:
-            self.serverSock = self.createOutboundSocket(
-                *self.address, insecure=self.insecure
-            )
-            self.serverSock.connect(self.address)
-        except ssl.SSLCertVerificationError:
-            fingerprint = None
-            try:
-                tmp_con = self.createOutboundSocket(*self.address, insecure=True)
-                tmp_con.connect(self.address)
-                certBin = tmp_con.getpeercert(True)
-                tmp_con.close()
-                fingerprint = hashlib.sha256(certBin).hexdigest().lower()
-            except Exception:
-                pass
-            config = configuration.get_config()
-            if (
-                hostPortToAddress(self.address) in config["trusted_certs"]
-                and config["trusted_certs"][hostPortToAddress(self.address)]
-                == fingerprint
-            ):
-                self.insecure = True
-                return self.run()
-            self.lastFailFingerprint = fingerprint
-            self.transportCertificateAuthenticationFailed.notify()
-            raise
-        except Exception:
-            self.transportConnectionFailed.notify()
-            raise
-        self.onTransportConnected()
-        self.queueThread = threading.Thread(target=self.sendQueue)
-        self.queueThread.daemon = True
-        self.queueThread.start()
-        while self.serverSock is not None:
-            try:
-                readers, writers, error = select.select(
-                    [self.serverSock], [], [self.serverSock]
-                )
-            except socket.error:
-                self.buffer = b""
-                break
-            if self.serverSock in error:
-                self.buffer = b""
-                break
-            if self.serverSock in readers:
-                try:
-                    self.processIncomingSocketData()
-                except socket.error:
-                    self.buffer = b""
-                    break
-        self.connected = False
-        self.connectedEvent.clear()
-        self.transportDisconnected.notify()
-        self._disconnect()
+	def run(self) -> None:
+		self.closed = False
+		try:
+			self.serverSock = self.createOutboundSocket(
+				*self.address, insecure=self.insecure
+			)
+			self.serverSock.connect(self.address)
+		except ssl.SSLCertVerificationError:
+			fingerprint = None
+			try:
+				tmp_con = self.createOutboundSocket(*self.address, insecure=True)
+				tmp_con.connect(self.address)
+				certBin = tmp_con.getpeercert(True)
+				tmp_con.close()
+				fingerprint = hashlib.sha256(certBin).hexdigest().lower()
+			except Exception:
+				pass
+			config = configuration.get_config()
+			if (
+				hostPortToAddress(self.address) in config["trusted_certs"]
+				and config["trusted_certs"][hostPortToAddress(self.address)]
+				== fingerprint
+			):
+				self.insecure = True
+				return self.run()
+			self.lastFailFingerprint = fingerprint
+			self.transportCertificateAuthenticationFailed.notify()
+			raise
+		except Exception:
+			self.transportConnectionFailed.notify()
+			raise
+		self.onTransportConnected()
+		self.queueThread = threading.Thread(target=self.sendQueue)
+		self.queueThread.daemon = True
+		self.queueThread.start()
+		while self.serverSock is not None:
+			try:
+				readers, writers, error = select.select(
+					[self.serverSock], [], [self.serverSock]
+				)
+			except socket.error:
+				self.buffer = b""
+				break
+			if self.serverSock in error:
+				self.buffer = b""
+				break
+			if self.serverSock in readers:
+				try:
+					self.processIncomingSocketData()
+				except socket.error:
+					self.buffer = b""
+					break
+		self.connected = False
+		self.connectedEvent.clear()
+		self.transportDisconnected.notify()
+		self._disconnect()
 
-    def createOutboundSocket(
-        self, host: str, port: int, insecure: bool = False
-    ) -> ssl.SSLSocket:
-        """Create and configure an SSL socket for outbound connections.
+	def createOutboundSocket(
+		self, host: str, port: int, insecure: bool = False
+	) -> ssl.SSLSocket:
+		"""Create and configure an SSL socket for outbound connections.
 
-        Creates a TCP socket with appropriate timeout and keep-alive settings,
-        then wraps it with SSL/TLS encryption.
+		Creates a TCP socket with appropriate timeout and keep-alive settings,
+		then wraps it with SSL/TLS encryption.
 
-        Args:
-                host (str): Remote hostname to connect to
-                port (int): Remote port number
-                insecure (bool, optional): Skip certificate verification. Defaults to False.
+		Args:
+				host (str): Remote hostname to connect to
+				port (int): Remote port number
+				insecure (bool, optional): Skip certificate verification. Defaults to False.
 
-        Returns:
-                ssl.SSLSocket: Configured SSL socket ready for connection
+		Returns:
+				ssl.SSLSocket: Configured SSL socket ready for connection
 
-        Note:
-                The socket is created but not yet connected. Call connect() separately.
-        """
-        address = socket.getaddrinfo(host, port)[0]
-        serverSock = socket.socket(*address[:3])
-        if self.timeout:
-            serverSock.settimeout(self.timeout)
-        serverSock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-        serverSock.ioctl(socket.SIO_KEEPALIVE_VALS, (1, 60000, 2000))
-        ctx = ssl.SSLContext()
-        if insecure:
-            ctx.verify_mode = ssl.CERT_NONE
-        ctx.check_hostname = not insecure
-        ctx.load_default_certs()
-        serverSock = ctx.wrap_socket(sock=serverSock, server_hostname=host)
-        return serverSock
+		Note:
+				The socket is created but not yet connected. Call connect() separately.
+		"""
+		address = socket.getaddrinfo(host, port)[0]
+		serverSock = socket.socket(*address[:3])
+		if self.timeout:
+			serverSock.settimeout(self.timeout)
+		serverSock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+		serverSock.ioctl(socket.SIO_KEEPALIVE_VALS, (1, 60000, 2000))
+		ctx = ssl.SSLContext()
+		if insecure:
+			ctx.verify_mode = ssl.CERT_NONE
+		ctx.check_hostname = not insecure
+		ctx.load_default_certs()
+		serverSock = ctx.wrap_socket(sock=serverSock, server_hostname=host)
+		return serverSock
 
-    def getpeercert(
-        self, binary_form: bool = False
-    ) -> Optional[Union[Dict[str, Any], bytes]]:
-        """Get the certificate from the peer.
+	def getpeercert(
+		self, binary_form: bool = False
+	) -> Optional[Union[Dict[str, Any], bytes]]:
+		"""Get the certificate from the peer.
 
-        Retrieves the certificate presented by the remote peer during SSL handshake.
+		Retrieves the certificate presented by the remote peer during SSL handshake.
 
-        Args:
-                binary_form (bool, optional): If True, return the raw certificate bytes.
-                        If False, return a parsed dictionary. Defaults to False.
+		Args:
+				binary_form (bool, optional): If True, return the raw certificate bytes.
+						If False, return a parsed dictionary. Defaults to False.
 
-        Returns:
-                Optional[Union[Dict[str, Any], bytes]]: The peer's certificate, or None if not connected.
-                        Format depends on binary_form parameter.
-        """
-        if self.serverSock is None:
-            return None
-        return self.serverSock.getpeercert(binary_form)
+		Returns:
+				Optional[Union[Dict[str, Any], bytes]]: The peer's certificate, or None if not connected.
+						Format depends on binary_form parameter.
+		"""
+		if self.serverSock is None:
+			return None
+		return self.serverSock.getpeercert(binary_form)
 
-    def processIncomingSocketData(self) -> None:
-        """Process incoming data from the server socket.
+	def processIncomingSocketData(self) -> None:
+		"""Process incoming data from the server socket.
 
-        Reads available data from the socket, buffers partial messages,
-        and processes complete messages by passing them to parse().
+		Reads available data from the socket, buffers partial messages,
+		and processes complete messages by passing them to parse().
 
-        Messages are expected to be newline-delimited.
-        Partial messages are stored in self.buffer until complete.
+		Messages are expected to be newline-delimited.
+		Partial messages are stored in self.buffer until complete.
 
-        Note:
-                This method handles SSL-specific socket behavior and non-blocking reads.
-                It is called when select() indicates data is available.
-        """
-        # This approach may be problematic:
-        # See also server.py handle_data in class Client.
-        buffSize = 16384
-        with self.serverSockLock:
-            # select operates on the raw socket. Even though it said there was data to
-            # read, that might be SSL data which might not result in actual data for
-            # us. Therefore, do a non-blocking read so SSL doesn't try to wait for
-            # more data for us.
-            # We don't make the socket non-blocking earlier because then we'd have to
-            # handle retries during the SSL handshake.
-            # See https://stackoverflow.com/questions/3187565/select-and-ssl-in-python
-            # and https://docs.python.org/3/library/ssl.html#notes-on-non-blocking-sockets
-            self.serverSock.setblocking(False)
-            try:
-                data = self.buffer + self.serverSock.recv(buffSize)
-            except ssl.SSLWantReadError:
-                # There's no data for us.
-                return
-            finally:
-                self.serverSock.setblocking(True)
-        self.buffer = b""
-        if not data:
-            self._disconnect()
-            return
-        if b"\n" not in data:
-            self.buffer += data
-            return
-        while b"\n" in data:
-            line, sep, data = data.partition(b"\n")
-            self.parse(line)
-        self.buffer += data
+		Note:
+				This method handles SSL-specific socket behavior and non-blocking reads.
+				It is called when select() indicates data is available.
+		"""
+		# This approach may be problematic:
+		# See also server.py handle_data in class Client.
+		buffSize = 16384
+		with self.serverSockLock:
+			# select operates on the raw socket. Even though it said there was data to
+			# read, that might be SSL data which might not result in actual data for
+			# us. Therefore, do a non-blocking read so SSL doesn't try to wait for
+			# more data for us.
+			# We don't make the socket non-blocking earlier because then we'd have to
+			# handle retries during the SSL handshake.
+			# See https://stackoverflow.com/questions/3187565/select-and-ssl-in-python
+			# and https://docs.python.org/3/library/ssl.html#notes-on-non-blocking-sockets
+			self.serverSock.setblocking(False)
+			try:
+				data = self.buffer + self.serverSock.recv(buffSize)
+			except ssl.SSLWantReadError:
+				# There's no data for us.
+				return
+			finally:
+				self.serverSock.setblocking(True)
+		self.buffer = b""
+		if not data:
+			self._disconnect()
+			return
+		if b"\n" not in data:
+			self.buffer += data
+			return
+		while b"\n" in data:
+			line, sep, data = data.partition(b"\n")
+			self.parse(line)
+		self.buffer += data
 
-    def parse(self, line: bytes) -> None:
-        """Parse and handle a complete message line.
+	def parse(self, line: bytes) -> None:
+		"""Parse and handle a complete message line.
 
-        Deserializes a message and routes it to the appropriate handler based on type.
+		Deserializes a message and routes it to the appropriate handler based on type.
 
-        Args:
-                line (bytes): Complete message line to parse
+		Args:
+				line (bytes): Complete message line to parse
 
-        Note:
-                Messages must include a 'type' field matching a RemoteMessageType enum value.
-                Handler callbacks are executed asynchronously on the wx main thread.
-                Invalid or unhandled message types are logged as errors.
-        """
-        obj = self.serializer.deserialize(line)
-        if "type" not in obj:
-            log.error("Received message without type: %r" % obj)
-            return
-        try:
-            messageType = RemoteMessageType(obj["type"])
-        except ValueError:
-            log.error("Received message with invalid type: %r" % obj)
-            return
-        del obj["type"]
-        extensionPoint = self.inboundHandlers.get(messageType)
-        if not extensionPoint:
-            log.error("Received message with unhandled type: %r" % obj)
-            return
-        wx.CallAfter(extensionPoint.notify, **obj)
+		Note:
+				Messages must include a 'type' field matching a RemoteMessageType enum value.
+				Handler callbacks are executed asynchronously on the wx main thread.
+				Invalid or unhandled message types are logged as errors.
+		"""
+		obj = self.serializer.deserialize(line)
+		if "type" not in obj:
+			log.error("Received message without type: %r" % obj)
+			return
+		try:
+			messageType = RemoteMessageType(obj["type"])
+		except ValueError:
+			log.error("Received message with invalid type: %r" % obj)
+			return
+		del obj["type"]
+		extensionPoint = self.inboundHandlers.get(messageType)
+		if not extensionPoint:
+			log.error("Received message with unhandled type: %r" % obj)
+			return
+		wx.CallAfter(extensionPoint.notify, **obj)
 
-    def sendQueue(self) -> None:
-        """Background thread that processes the outbound message queue.
+	def sendQueue(self) -> None:
+		"""Background thread that processes the outbound message queue.
 
-        Continuously pulls messages from the queue and sends them over the socket.
-        Thread exits when None is received from the queue or a socket error occurs.
+		Continuously pulls messages from the queue and sends them over the socket.
+		Thread exits when None is received from the queue or a socket error occurs.
 
-        Note:
-                This method runs in a separate thread and handles thread-safe socket access
-                using the serverSockLock.
-        """
-        while True:
-            item = self.queue.get()
-            if item is None:
-                return
-            try:
-                with self.serverSockLock:
-                    self.serverSock.sendall(item)
-            except socket.error:
-                return
+		Note:
+				This method runs in a separate thread and handles thread-safe socket access
+				using the serverSockLock.
+		"""
+		while True:
+			item = self.queue.get()
+			if item is None:
+				return
+			try:
+				with self.serverSockLock:
+					self.serverSock.sendall(item)
+			except socket.error:
+				return
 
-    def send(self, type: str | Enum, **kwargs: Any) -> None:
-        """Send a message through the transport.
+	def send(self, type: str | Enum, **kwargs: Any) -> None:
+		"""Send a message through the transport.
 
-        Serializes and queues a message for transmission. Messages are sent
-        asynchronously by the queue thread.
+		Serializes and queues a message for transmission. Messages are sent
+		asynchronously by the queue thread.
 
-        Args:
-                type (str|Enum): Message type, typically a RemoteMessageType enum value
-                **kwargs: Message payload data to serialize
+		Args:
+				type (str|Enum): Message type, typically a RemoteMessageType enum value
+				**kwargs: Message payload data to serialize
 
-        Note:
-                This method is thread-safe and can be called from any thread.
-                If the transport is not connected, the message will be silently dropped.
-        """
-        if self.connected:
-            obj = self.serializer.serialize(type=type, **kwargs)
-            self.queue.put(obj)
-        else:
-            log.error("Attempted to send message %r while not connected", type)
+		Note:
+				This method is thread-safe and can be called from any thread.
+				If the transport is not connected, the message will be silently dropped.
+		"""
+		if self.connected:
+			obj = self.serializer.serialize(type=type, **kwargs)
+			self.queue.put(obj)
+		else:
+			log.error("Attempted to send message %r while not connected", type)
 
-    def _disconnect(self) -> None:
-        """Internal method to disconnect the transport.
+	def _disconnect(self) -> None:
+		"""Internal method to disconnect the transport.
 
-        Cleans up the send queue thread, empties queued messages,
-        and closes the socket connection.
+		Cleans up the send queue thread, empties queued messages,
+		and closes the socket connection.
 
-        Note:
-                This is called internally on errors, unlike close() which is called
-                explicitly to shut down the transport.
-        """
-        """Disconnect the transport due to an error, without closing the connector thread."""
-        if self.queueThread is not None:
-            self.queue.put(None)
-            self.queueThread.join()
-            self.queueThread = None
-        clearQueue(self.queue)
-        if self.serverSock:
-            self.serverSock.close()
-            self.serverSock = None
+		Note:
+				This is called internally on errors, unlike close() which is called
+				explicitly to shut down the transport.
+		"""
+		"""Disconnect the transport due to an error, without closing the connector thread."""
+		if self.queueThread is not None:
+			self.queue.put(None)
+			self.queueThread.join()
+			self.queueThread = None
+		clearQueue(self.queue)
+		if self.serverSock:
+			self.serverSock.close()
+			self.serverSock = None
 
-    def close(self):
-        """Close the transport."""
-        self.transportClosing.notify()
-        self.reconnectorThread.running = False
-        self._disconnect()
-        self.closed = True
-        self.reconnectorThread = ConnectorThread(self)
+	def close(self):
+		"""Close the transport."""
+		self.transportClosing.notify()
+		self.reconnectorThread.running = False
+		self._disconnect()
+		self.closed = True
+		self.reconnectorThread = ConnectorThread(self)
 
 
 class RelayTransport(TCPTransport):
-    """Transport for connecting through a relay server.
+	"""Transport for connecting through a relay server.
 
-    Extends TCPTransport with relay-specific protocol handling for channels
-    and connection types. Manages protocol versioning and channel joining.
+	Extends TCPTransport with relay-specific protocol handling for channels
+	and connection types. Manages protocol versioning and channel joining.
 
-    Args:
-        serializer (Serializer): Message serializer instance
-        address (Tuple[str, int]): Relay server address
-        timeout (int, optional): Connection timeout. Defaults to 0.
-        channel (Optional[str], optional): Channel to join. Defaults to None.
-        connectionType (Optional[str], optional): Connection type. Defaults to None.
-        protocol_version (int, optional): Protocol version. Defaults to PROTOCOL_VERSION.
-        insecure (bool, optional): Skip certificate verification. Defaults to False.
+	Args:
+		serializer (Serializer): Message serializer instance
+		address (Tuple[str, int]): Relay server address
+		timeout (int, optional): Connection timeout. Defaults to 0.
+		channel (Optional[str], optional): Channel to join. Defaults to None.
+		connectionType (Optional[str], optional): Connection type. Defaults to None.
+		protocol_version (int, optional): Protocol version. Defaults to PROTOCOL_VERSION.
+		insecure (bool, optional): Skip certificate verification. Defaults to False.
 
-    Attributes:
-        channel (Optional[str]): Relay channel name
-        connectionType (Optional[str]): Type of relay connection
-        protocol_version (int): Protocol version to use
-    """
+	Attributes:
+		channel (Optional[str]): Relay channel name
+		connectionType (Optional[str]): Type of relay connection
+		protocol_version (int): Protocol version to use
+	"""
 
-    channel: Optional[str]
-    connectionType: Optional[str]
-    protocol_version: int
+	channel: Optional[str]
+	connectionType: Optional[str]
+	protocol_version: int
 
-    def __init__(
-        self,
-        serializer: Serializer,
-        address: Tuple[str, int],
-        timeout: int = 0,
-        channel: Optional[str] = None,
-        connectionType: Optional[str] = None,
-        protocol_version: int = PROTOCOL_VERSION,
-        insecure: bool = False,
-    ) -> None:
-        """Initialize a new RelayTransport instance.
+	def __init__(
+		self,
+		serializer: Serializer,
+		address: Tuple[str, int],
+		timeout: int = 0,
+		channel: Optional[str] = None,
+		connectionType: Optional[str] = None,
+		protocol_version: int = PROTOCOL_VERSION,
+		insecure: bool = False,
+	) -> None:
+		"""Initialize a new RelayTransport instance.
 
-        Args:
-            serializer: Serializer for encoding/decoding messages
-            address: Tuple of (host, port) to connect to
-            timeout: Connection timeout in seconds
-            channel: Optional channel name to join
-            connectionType: Optional connection type identifier
-            protocol_version: Protocol version to use
-            insecure: Whether to skip certificate verification
-        """
-        super().__init__(
-            address=address, serializer=serializer, timeout=timeout, insecure=insecure
-        )
-        log.info("Connecting to %s channel %s" % (address, channel))
-        self.channel = channel
-        self.connectionType = connectionType
-        self.protocol_version = protocol_version
-        self.transportConnected.register(self.onConnected)
+		Args:
+			serializer: Serializer for encoding/decoding messages
+			address: Tuple of (host, port) to connect to
+			timeout: Connection timeout in seconds
+			channel: Optional channel name to join
+			connectionType: Optional connection type identifier
+			protocol_version: Protocol version to use
+			insecure: Whether to skip certificate verification
+		"""
+		super().__init__(
+			address=address, serializer=serializer, timeout=timeout, insecure=insecure
+		)
+		log.info("Connecting to %s channel %s" % (address, channel))
+		self.channel = channel
+		self.connectionType = connectionType
+		self.protocol_version = protocol_version
+		self.transportConnected.register(self.onConnected)
 
-    @classmethod
-    def create(cls, connection_info: ConnectionInfo, serializer: Serializer) -> "RelayTransport":
-        """Create a RelayTransport from a ConnectionInfo object.
-        
-        Args:
-            connection_info: ConnectionInfo instance containing connection details
-            serializer: Serializer instance for message encoding/decoding
-            
-        Returns:
-            Configured RelayTransport instance ready for connection
-        """
-        return cls(
-            serializer=serializer,
-            address=(connection_info.hostname, connection_info.port),
-            channel=connection_info.key,
-            connectionType=connection_info.mode.value,
-            insecure=connection_info.insecure
-        )
+	@classmethod
+	def create(cls, connection_info: ConnectionInfo, serializer: Serializer) -> "RelayTransport":
+		"""Create a RelayTransport from a ConnectionInfo object.
+		
+		Args:
+			connection_info: ConnectionInfo instance containing connection details
+			serializer: Serializer instance for message encoding/decoding
+			
+		Returns:
+			Configured RelayTransport instance ready for connection
+		"""
+		return cls(
+			serializer=serializer,
+			address=(connection_info.hostname, connection_info.port),
+			channel=connection_info.key,
+			connectionType=connection_info.mode.value,
+			insecure=connection_info.insecure
+		)
 
-    def onConnected(self) -> None:
-        self.send(RemoteMessageType.protocol_version, version=self.protocol_version)
-        if self.channel is not None:
-            self.send(
-                RemoteMessageType.join,
-                channel=self.channel,
-                connection_type=self.connectionType,
-            )
-        else:
-            self.send(RemoteMessageType.generate_key)
+	def onConnected(self) -> None:
+		self.send(RemoteMessageType.protocol_version, version=self.protocol_version)
+		if self.channel is not None:
+			self.send(
+				RemoteMessageType.join,
+				channel=self.channel,
+				connection_type=self.connectionType,
+			)
+		else:
+			self.send(RemoteMessageType.generate_key)
 
 
 class ConnectorThread(threading.Thread):
-    """Background thread that manages connection attempts.
+	"""Background thread that manages connection attempts.
 
-    Handles automatic reconnection with configurable delay between attempts.
-    Runs until explicitly stopped.
+	Handles automatic reconnection with configurable delay between attempts.
+	Runs until explicitly stopped.
 
-    Args:
-        connector (Transport): Transport instance to manage connections for
-        reconnectDelay (int, optional): Seconds between attempts. Defaults to 5.
+	Args:
+		connector (Transport): Transport instance to manage connections for
+		reconnectDelay (int, optional): Seconds between attempts. Defaults to 5.
 
-    Attributes:
-        running (bool): Whether thread should continue running
-        connector (Transport): Transport to manage connections for
-        reconnectDelay (int): Seconds to wait between connection attempts
-    """
+	Attributes:
+		running (bool): Whether thread should continue running
+		connector (Transport): Transport to manage connections for
+		reconnectDelay (int): Seconds to wait between connection attempts
+	"""
 
-    running: bool
-    connector: Transport
-    reconnectDelay: int
+	running: bool
+	connector: Transport
+	reconnectDelay: int
 
-    def __init__(self, connector: Transport, reconnectDelay: int = 5) -> None:
-        super().__init__()
-        self.reconnectDelay = reconnectDelay
-        self.running = True
-        self.connector = connector
-        self.name = self.name + "_connector_loop"
-        self.daemon = True
+	def __init__(self, connector: Transport, reconnectDelay: int = 5) -> None:
+		super().__init__()
+		self.reconnectDelay = reconnectDelay
+		self.running = True
+		self.connector = connector
+		self.name = self.name + "_connector_loop"
+		self.daemon = True
 
-    def run(self):
-        while self.running:
-            try:
-                self.connector.run()
-            except socket.error:
-                time.sleep(self.reconnectDelay)
-                continue
-            else:
-                time.sleep(self.reconnectDelay)
-        log.info("Ending control connector thread %s" % self.name)
+	def run(self):
+		while self.running:
+			try:
+				self.connector.run()
+			except socket.error:
+				time.sleep(self.reconnectDelay)
+				continue
+			else:
+				time.sleep(self.reconnectDelay)
+		log.info("Ending control connector thread %s" % self.name)
 
 
 def clearQueue(queue: Queue[Optional[bytes]]) -> None:
-    """Empty all items from a queue without blocking.
+	"""Empty all items from a queue without blocking.
 
-    Removes all items from the queue in a non-blocking way,
-    useful for cleaning up before disconnection.
+	Removes all items from the queue in a non-blocking way,
+	useful for cleaning up before disconnection.
 
-    Args:
-        queue (Queue[Optional[bytes]]): Queue instance to clear
+	Args:
+		queue (Queue[Optional[bytes]]): Queue instance to clear
 
-    Note:
-        This function catches and ignores any exceptions that occur
-        while trying to get items from an empty queue.
-    """
-    try:
-        while True:
-            queue.get_nowait()
-    except Exception:
-        pass
+	Note:
+		This function catches and ignores any exceptions that occur
+		while trying to get items from an empty queue.
+	"""
+	try:
+		while True:
+			queue.get_nowait()
+	except Exception:
+		pass

--- a/addon/globalPlugins/remoteClient/transport.py
+++ b/addon/globalPlugins/remoteClient/transport.py
@@ -30,7 +30,7 @@ from logging import getLogger
 from queue import Queue
 from typing import Any, Callable, Dict, Optional, Tuple, Union
 
-from attr import dataclass
+from dataclasses import dataclass
 import wx
 from extensionPoints import Action, HandlerRegistrar
 


### PR DESCRIPTION
This PR moves NVDA Remote's sound and speech event handling from the patcher layer to use NVDA's native extension points directly. This simplifies the code and removes a layer of indirection.

## Changes
- Added `RemoteExtensionPoint` class to bridge NVDA extension points to remote messages 
- Moved speech, tone, and wave file events to use extension points directly instead of going through the patcher
- Events now flow: NVDA extension point -> Remote message -> Remote peer, instead of the previous: NVDA -> Patcher -> Callback -> Remote message -> Remote peer
- Removed redundant code in wave file handling and speech management
- Cleaned up imports and unused code

## Why?
- Simpler architecture - removes an unnecessary layer of event handling
- More reliable - uses NVDA's built-in extension points instead of our custom patcher
- Easier to maintain - less custom code and clearer event flow
- Sets up better patterns for future features
